### PR TITLE
fix SA name in placement role binding and reconcile retries

### DIFF
--- a/pkg/controller/gitopscluster/gitopscluster_controller_test.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller_test.go
@@ -213,7 +213,7 @@ var (
 	}
 
 	applicationsetRole = types.NamespacedName{
-		Name:      ROLENAME,
+		Name:      "argocd1" + RoleSuffix,
 		Namespace: "argocd1",
 	}
 


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/stolostron/backlog/issues/22215

- Get ArgoCD instance's application set controller SA name properly
- Fix reconcile retries when reconcile fails to verify the ArgoCD instance namespace