### PR TITLE
remove old API version and image rebuild

### DIFF
--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -551,7 +551,6 @@ func (r *ReconcileGitOpsCluster) CreateApplicationSetConfigMaps(namespace string
 	// Create two configMaps, one for placementrules.apps and placementdecisions.cluster
 	maps := []v1.ConfigMap{
 		getConfigMapDuck(configMapNameOld, namespace, "apps.open-cluster-management.io/v1", "placementrules"),
-		getConfigMapDuck(configMapNameNew, namespace, "cluster.open-cluster-management.io/v1alpha1", "placementdecisions"),
 		getConfigMapDuck(configMapNameNew, namespace, "cluster.open-cluster-management.io/v1beta1", "placementdecisions"),
 	}
 


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/stolostron/backlog/issues/22696

Remove the old placement API version.

This will trigger an image rebuild for https://github.com/stolostron/backlog/issues/23981 as well