### PR TITLE
managed cluster name is not displayed correctly in the gitopsCluster …

### DIFF
--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -352,7 +352,13 @@ func (r *ReconcileGitOpsCluster) reconcileGitOpsCluster(
 
 	instance.Status.LastUpdateTime = metav1.Now()
 	instance.Status.Phase = "successful"
-	instance.Status.Message = fmt.Sprintf("Added managed clusters %v to gitops namespace %s", managedClusters, instance.Spec.ArgoServer.ArgoNamespace)
+
+	managedClustersStr := strings.Join(managedClusterNames, " ")
+	if len(managedClustersStr) > 4096 {
+		managedClustersStr = fmt.Sprintf("%.4096v", managedClustersStr) + "..."
+	}
+
+	instance.Status.Message = fmt.Sprintf("Added managed clusters [%v] to gitops namespace %s", managedClustersStr, instance.Spec.ArgoServer.ArgoNamespace)
 
 	err = r.Client.Status().Update(context.TODO(), instance)
 


### PR DESCRIPTION
…status (#78)

Signed-off-by: Xiangjing Li <xiangli@redhat.com>
(cherry picked from commit 91a69fcc354e83291e42e9112c401186315d5c6f)