### PR TITLE
specifying a root certificates file with the insecure flag is not all…

### DIFF
--- a/gitopsaddon/gitopsaddon_controller.go
+++ b/gitopsaddon/gitopsaddon_controller.go
@@ -97,9 +97,6 @@ func (r *GitopsAddonReconciler) Start(ctx context.Context) error {
 		configFlags.CertFile = &r.Config.CertFile
 		configFlags.KeyFile = &r.Config.KeyFile
 
-		trueData := true
-		configFlags.Insecure = &trueData
-
 		r.houseKeeping(configFlags)
 	}, time.Duration(r.Interval)*time.Second, ctx.Done())
 


### PR DESCRIPTION
…owed on OCP >=4.16 (#113)

* [X] I have taken backward compatibility into consideration.
