### PR TITLE
ACM-17895 Add managedcluster labels to secret

### DIFF
--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -1198,6 +1198,14 @@ func (r *ReconcileGitOpsCluster) CreateMangedClusterSecretFromManagedServiceAcco
 		},
 	}
 
+	// Collect labels to add to the secret
+	// Labels created above have precedence
+	for key, val := range managedCluster.Labels {
+		if _, ok := newSecret.Labels[key]; !ok {
+			newSecret.Labels[key] = val
+		}
+	}
+
 	return newSecret, nil
 }
 


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.

https://issues.redhat.com/browse/ACM-17895

- Add managedcluster labels to secret

<img width="1040" alt="image" src="https://github.com/user-attachments/assets/addc7899-df79-4cd5-990a-9577b4661db0" />
