### PR TITLE
use go env GOARCH when building go binaries on vairous platforms

### DIFF
--- a/common/scripts/gobuild.sh
+++ b/common/scripts/gobuild.sh
@@ -28,8 +28,8 @@ shift
 
 set -e
 
-BUILD_GOOS=${GOOS:-linux}
-BUILD_GOARCH=${GOARCH:-amd64}
+BUILD_GOOS=${GOOS:-$(go env GOOS)}
+BUILD_GOARCH=${GOARCH:-$(go env GOARCH)}
 GOBINARY=${GOBINARY:-go}
 BUILDINFO=${BUILDINFO:-""}
 STATIC=${STATIC:-1}
@@ -44,6 +44,8 @@ export CGO_ENABLED=1
 if [[ "${STATIC}" !=  "1" ]];then
     LDFLAGS=""
 fi
+
+echo "Building for OS: ${BUILD_GOOS}, Architecture: ${BUILD_GOARCH}"
 
 time GOOS=${BUILD_GOOS} GOARCH=${BUILD_GOARCH} ${GOBINARY} build \
         ${V} "${GOBUILDFLAGS_ARRAY[@]}" ${GCFLAGS:+-gcflags "${GCFLAGS}"} \


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.

https://issues.redhat.com/browse/ACM-20550

Note: If this resolves the downstream build failure on s390x, the fix will be applied to all ALC repos.
