### PR TITLE
ACM-20496 Fix Gitops cluster secret cleanup

### DIFF
--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -41,6 +41,7 @@ linters:
     - interfacebloat
     - ireturn
     - loggercheck
+    - maintidx
     - musttag
     - mnd
     - nakedret

--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -887,7 +887,6 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 
 		var newSecret *v1.Secret
 		msaExists := false
-		longLivedSecretExists := false
 		managedClusterSecret := &v1.Secret{}
 		secretObjectKey := types.NamespacedName{
 			Name:      managedCluster.Name + clusterSecretSuffix,
@@ -943,8 +942,6 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 					secretName = managedCluster.Name + "-" + componentName + clusterSecretSuffix
 					managedClusterSecretKey = types.NamespacedName{Name: secretName, Namespace: managedCluster.Name}
 					err = r.Get(context.TODO(), managedClusterSecretKey, managedClusterSecret)
-				} else {
-					longLivedSecretExists = true
 				}
 			}
 
@@ -1041,7 +1038,7 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 		}
 
 		// Cleanup managed cluster secret from managed cluster namespace
-		if longLivedSecretExists && msaExists {
+		if msaExists {
 			longLivedSecretKey := types.NamespacedName{
 				Name:      managedCluster.Name + clusterSecretSuffix,
 				Namespace: managedCluster.Name,

--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -86,6 +86,8 @@ var _ reconcile.Reconciler = &ReconcileGitOpsCluster{}
 
 var errInvalidPlacementRef = errors.New("invalid placement reference")
 
+const clusterSecretSuffix = "-cluster-secret"
+
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 	authCfg := mgr.GetConfig()
@@ -885,6 +887,16 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 
 		var newSecret *v1.Secret
 		msaExists := false
+		longLivedSecretExists := false
+		managedClusterSecret := &v1.Secret{}
+		secretObjectKey := types.NamespacedName{
+			Name:      managedCluster.Name + clusterSecretSuffix,
+			Namespace: argoNamespace,
+		}
+		msaSecretObjectKey := types.NamespacedName{
+			Name:      managedCluster.Name + "-" + componentName + clusterSecretSuffix,
+			Namespace: argoNamespace,
+		}
 
 		// Check if there are existing non-acm created cluster secrets
 		if len(nonAcmClusterSecrets[managedCluster.Name]) > 0 {
@@ -893,53 +905,57 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 
 			errorOccurred = true
 
+			saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
 			continue
 		}
 
 		if createBlankClusterSecrets || gitOpsCluster.Spec.ManagedServiceAccountRef == "" {
-			secretName := managedCluster.Name + "-cluster-secret"
-			managedClusterSecretKey := types.NamespacedName{Name: secretName, Namespace: managedCluster.Name}
+			// check for a ManagedServiceAccount to see if we need to create the secret
+			ManagedServiceAccount := &authv1beta1.ManagedServiceAccount{}
+			ManagedServiceAccountName := types.NamespacedName{Namespace: managedCluster.Name, Name: componentName}
+			err = r.Get(context.TODO(), ManagedServiceAccountName, ManagedServiceAccount)
 
-			managedClusterSecret := &v1.Secret{}
-			err := r.Get(context.TODO(), managedClusterSecretKey, managedClusterSecret)
-
-			if err != nil {
-				// try with CreateMangedClusterSecretFromManagedServiceAccount generated name
-				secretName = managedCluster.Name + "-" + componentName + "-cluster-secret"
-				managedClusterSecretKey = types.NamespacedName{Name: secretName, Namespace: managedCluster.Name}
+			if err == nil {
+				// get ManagedServiceAccount secret
+				managedClusterSecretKey := types.NamespacedName{Name: componentName, Namespace: managedCluster.Name}
 				err = r.Get(context.TODO(), managedClusterSecretKey, managedClusterSecret)
+
+				if err == nil {
+					klog.Infof("Found ManagedServiceAccount %s created by managed cluster %s", componentName, managedCluster.Name)
+					msaExists = true
+				} else {
+					klog.Error("failed to find ManagedServiceAccount created secret application-manager")
+
+					saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
+					continue
+				}
+			} else {
+				// fallback to old code
+				klog.Infof("Failed to find ManagedServiceAccount CR in namespace %s", managedCluster.Name)
+				secretName := managedCluster.Name + clusterSecretSuffix
+				managedClusterSecretKey := types.NamespacedName{Name: secretName, Namespace: managedCluster.Name}
+
+				err = r.Get(context.TODO(), managedClusterSecretKey, managedClusterSecret)
+
+				if err != nil {
+					// try with CreateMangedClusterSecretFromManagedServiceAccount generated name
+					secretName = managedCluster.Name + "-" + componentName + clusterSecretSuffix
+					managedClusterSecretKey = types.NamespacedName{Name: secretName, Namespace: managedCluster.Name}
+					err = r.Get(context.TODO(), managedClusterSecretKey, managedClusterSecret)
+				} else {
+					longLivedSecretExists = true
+				}
 			}
 
 			// managed cluster secret doesn't need to exist for pull model
 			if err != nil && !createBlankClusterSecrets {
-				// check for a ManagedServiceAccount to see if we need to create the secret
-				ManagedServiceAccount := &authv1beta1.ManagedServiceAccount{}
-				ManagedServiceAccountName := types.NamespacedName{Namespace: managedCluster.Name, Name: componentName}
-				err = r.Get(context.TODO(), ManagedServiceAccountName, ManagedServiceAccount)
+				klog.Error("failed to get managed cluster secret. err: ", err.Error())
 
-				if err == nil {
-					// get the secret
-					managedClusterSecretKey = types.NamespacedName{Name: componentName, Namespace: managedCluster.Name}
-					err = r.Get(context.TODO(), managedClusterSecretKey, managedClusterSecret)
+				errorOccurred = true
+				returnErr = err
 
-					if err == nil {
-						klog.Infof("Found ManagedServiceAccount %s created by managed cluster %s", componentName, managedCluster.Name)
-						msaExists = true
-					} else {
-						klog.Error("failed to find ManagedServiceAccount created secret application-manager")
-					}
-				} else {
-					klog.Error("failed to find ManagedServiceAccount CR in namespace " + managedCluster.Name)
-				}
-
-				if !msaExists {
-					klog.Error("failed to get managed cluster secret. err: ", err.Error())
-
-					errorOccurred = true
-					returnErr = err
-
-					continue
-				}
+				saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
+				continue
 			}
 
 			if msaExists {
@@ -956,6 +972,7 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 				errorOccurred = true
 				returnErr = err
 
+				saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
 				continue
 			}
 		} else {
@@ -968,6 +985,7 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 				errorOccurred = true
 				returnErr = err
 
+				saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
 				continue
 			}
 		}
@@ -988,6 +1006,7 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 				errorOccurred = true
 				returnErr = err
 
+				saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
 				continue
 			}
 		} else if k8errors.IsNotFound(err) {
@@ -1001,6 +1020,7 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 				errorOccurred = true
 				returnErr = err
 
+				saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
 				continue
 			}
 		} else {
@@ -1008,8 +1028,30 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 
 			errorOccurred = true
 			returnErr = err
-
+			saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
 			continue
+		}
+
+		// Cleanup managed cluster secret from managed cluster namespace
+		if longLivedSecretExists && msaExists {
+			longLivedSecretKey := types.NamespacedName{
+				Name:      managedCluster.Name + clusterSecretSuffix,
+				Namespace: managedCluster.Name,
+			}
+			err := r.Get(context.TODO(), longLivedSecretKey, managedClusterSecret)
+
+			if err != nil && k8errors.IsNotFound(err) {
+				klog.Infof("Long lived token secret cleaned up already")
+			} else if err != nil && !k8errors.IsNotFound(err) {
+				klog.Infof("Failed to get long lived token secret to cleaned up. Error: %v", err)
+			} else {
+				err = r.Delete(context.TODO(), managedClusterSecret)
+				if err != nil {
+					klog.Infof("Failed to clean up long lived token secret. Error %v", err)
+				} else {
+					klog.Infof("Cleaned up long lived token secret succefully")
+				}
+			}
 		}
 
 		// Managed cluster secret successfully created/updated - remove from orphan list
@@ -1021,6 +1063,11 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 	}
 
 	return returnErr
+}
+
+func saveClusterSecret(orphanSecretsList map[types.NamespacedName]string, secretObjectKey, msaSecretObjectKey types.NamespacedName) {
+	delete(orphanSecretsList, secretObjectKey)
+	delete(orphanSecretsList, msaSecretObjectKey)
 }
 
 // CreateManagedClusterSecretInArgo creates a managed cluster secret with specific metadata in Argo namespace
@@ -1038,7 +1085,7 @@ func (r *ReconcileGitOpsCluster) CreateManagedClusterSecretInArgo(argoNamespace 
 				APIVersion: "v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      managedCluster.Name + "-cluster-secret",
+				Name:      managedCluster.Name + clusterSecretSuffix,
 				Namespace: argoNamespace,
 				Labels: map[string]string{
 					"argocd.argoproj.io/secret-type":                 "cluster",
@@ -1196,7 +1243,6 @@ func (r *ReconcileGitOpsCluster) CreateMangedClusterSecretFromManagedServiceAcco
 				"apps.open-cluster-management.io/acm-cluster":    "true",
 				"apps.open-cluster-management.io/cluster-name":   managedCluster.Name,
 				"apps.open-cluster-management.io/cluster-server": fmt.Sprintf("%.63s", strippedClusterURL),
-				"cluster.open-cluster-management.io/backup":      "",
 			},
 		},
 		Type: "Opaque",

--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -906,6 +906,7 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 			errorOccurred = true
 
 			saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
+
 			continue
 		}
 
@@ -925,8 +926,8 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 					msaExists = true
 				} else {
 					klog.Error("failed to find ManagedServiceAccount created secret application-manager")
-
 					saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
+
 					continue
 				}
 			} else {
@@ -955,6 +956,7 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 				returnErr = err
 
 				saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
+
 				continue
 			}
 
@@ -973,6 +975,7 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 				returnErr = err
 
 				saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
+
 				continue
 			}
 		} else {
@@ -986,6 +989,7 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 				returnErr = err
 
 				saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
+
 				continue
 			}
 		}
@@ -1007,6 +1011,7 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 				returnErr = err
 
 				saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
+
 				continue
 			}
 		} else if k8errors.IsNotFound(err) {
@@ -1021,6 +1026,7 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 				returnErr = err
 
 				saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
+
 				continue
 			}
 		} else {
@@ -1028,7 +1034,9 @@ func (r *ReconcileGitOpsCluster) AddManagedClustersToArgo(
 
 			errorOccurred = true
 			returnErr = err
+
 			saveClusterSecret(orphanSecretsList, secretObjectKey, msaSecretObjectKey)
+
 			continue
 		}
 

--- a/pkg/controller/gitopscluster/gitopscluster_controller_test.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller_test.go
@@ -268,6 +268,159 @@ var (
 		},
 	}
 
+	// Test7 resources
+	test7GitopsServerNamespace7 = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openshift-gitops7",
+		},
+	}
+
+	test7ArgoService = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argo-server7",
+			Namespace: test7GitopsServerNamespace7.Name,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of":   "argocd",
+				"app.kubernetes.io/component": "server",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP:       "10.0.0.17",
+			SessionAffinity: corev1.ServiceAffinityNone,
+			Type:            corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Port:       int32(443),
+					TargetPort: intstr.FromInt(443),
+				},
+			},
+		},
+	}
+
+	test7GitopsPlacement = &clusterv1beta1.Placement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "git-ops-placement-7",
+			Namespace: test7GitopsServerNamespace7.Name,
+		},
+		Spec: clusterv1beta1.PlacementSpec{},
+	}
+
+	test7GitopsCluster = &gitopsclusterV1beta1.GitOpsCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "git-ops-cluster-7",
+			Namespace: test7GitopsServerNamespace7.Name,
+		},
+		Spec: gitopsclusterV1beta1.GitOpsClusterSpec{
+			ArgoServer: gitopsclusterV1beta1.ArgoServerSpec{
+				Cluster:       "local-cluster",
+				ArgoNamespace: test7GitopsServerNamespace7.Name,
+			},
+			PlacementRef: &corev1.ObjectReference{
+				Kind:       "Placement",
+				APIVersion: "cluster.open-cluster-management.io/v1beta1",
+				Namespace:  test7GitopsServerNamespace7.Name,
+				Name:       "git-ops-placement-7",
+			},
+		},
+	}
+
+	test7ManagedClusterNamespace7 = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster7",
+		},
+	}
+
+	test7ManagedCluster7 = &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster7",
+			Labels: map[string]string{
+				"test-label": "test-value",
+			},
+		},
+		Spec: clusterv1.ManagedClusterSpec{
+			HubAcceptsClient: true,
+			ManagedClusterClientConfigs: []clusterv1.ClientConfig{
+				{
+					URL:      "https://local-cluster:6443",
+					CABundle: []byte("abc"),
+				},
+			},
+		},
+	}
+
+	test7GitopsPlacementDecision = &clusterv1beta1.PlacementDecision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "git-ops-placement-decision-7",
+			Namespace: test7GitopsServerNamespace7.Name,
+			Labels: map[string]string{
+				"cluster.open-cluster-management.io/placement": "git-ops-placement-7",
+			},
+		},
+		Status: clusterv1beta1.PlacementDecisionStatus{
+			Decisions: []clusterv1beta1.ClusterDecision{
+				{
+					ClusterName: test7ManagedCluster7.Name,
+				},
+			},
+		},
+	}
+
+	test7ManagedClusterSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster7-cluster-secret",
+			Namespace: test7ManagedCluster7.Name,
+			Labels: map[string]string{
+				"apps.open-cluster-management.io/secret-type": "acm-cluster",
+			},
+		},
+		StringData: map[string]string{
+			"name":   test7ManagedCluster7.Name,
+			"server": "https://api.cluster7.com:6443",
+			"config": "{\"bearerToken\": \"fakeToken1\", \"tlsClientConfig\": {\"insecure\": true}}",
+		},
+	}
+
+	test7ManagedServiceAccount = &authv1beta1.ManagedServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "application-manager",
+			Namespace: test7ManagedCluster7.Name,
+		},
+		Spec: authv1beta1.ManagedServiceAccountSpec{
+			Rotation: authv1beta1.ManagedServiceAccountRotation{
+				Enabled: true,
+				Validity: metav1.Duration{
+					Duration: time.Hour * 168,
+				},
+			},
+		},
+	}
+
+	test7MSASecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "application-manager",
+			Namespace: test7ManagedCluster7.Name,
+		},
+		StringData: map[string]string{
+			"token":  "token1",
+			"ca.crt": "caCrt1",
+		},
+	}
+
+	test7GitopsNSSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster7-application-manager-cluster-secret",
+			Namespace: test7ManagedCluster7.Name,
+			Labels: map[string]string{
+				"apps.open-cluster-management.io/secret-type": "acm-cluster",
+			},
+		},
+		StringData: map[string]string{
+			"name":   test7ManagedCluster7.Name,
+			"server": "https://api.cluster7.com:6443",
+			"config": "{\"bearerToken\": \"fakeToken1\", \"tlsClientConfig\": {\"insecure\": true}}",
+		},
+	}
+
 	// Namespace where GitOpsCluster1 CR is
 	testNamespace1 = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1015,24 +1168,25 @@ func TestReconcileCreateSecretInOpenshiftGitops(t *testing.T) {
 	// Creat Gitops placement decision
 	c.Create(context.TODO(), test6GitopsPlacementDecision)
 
-	tempPlacementDecisionObject := &clusterv1beta1.PlacementDecision{}
-	err = c.Get(context.TODO(), types.NamespacedName{
-		Name:      test6GitopsPlacementDecision.Name,
-		Namespace: test6GitopsPlacementDecision.Namespace,
-	}, tempPlacementDecisionObject)
-
-	g.Expect(err).To(gomega.BeNil())
-
-	tempPlacementDecisionObject.Status = clusterv1beta1.PlacementDecisionStatus{
-		Decisions: []clusterv1beta1.ClusterDecision{
-			{
-				ClusterName: test6ManagedCluster6.Name,
-				Reason:      "",
+	g.Eventually(func(g2 gomega.Gomega) {
+		tempPlacementDecisionObject := expectedPlacementDecisionCreated(c,
+			types.NamespacedName{
+				Name:      test6GitopsPlacementDecision.Name,
+				Namespace: test6GitopsPlacementDecision.Namespace,
 			},
-		},
-	}
+		)
 
-	c.Status().Update(context.TODO(), tempPlacementDecisionObject)
+		tempPlacementDecisionObject.Status = clusterv1beta1.PlacementDecisionStatus{
+			Decisions: []clusterv1beta1.ClusterDecision{
+				{
+					ClusterName: test6ManagedCluster6.Name,
+					Reason:      "",
+				},
+			},
+		}
+
+		g2.Expect(c.Status().Update(context.TODO(), tempPlacementDecisionObject)).Should(gomega.Succeed())
+	}, 60*time.Second, 1*time.Second).Should(gomega.Succeed())
 
 	// Create GitopsCluster
 	c.Create(context.TODO(), test6GitopsCluster)
@@ -1044,6 +1198,89 @@ func TestReconcileCreateSecretInOpenshiftGitops(t *testing.T) {
 	})
 
 	g.Expect(test6ClusterSecret).To(gomega.BeNil())
+
+	// Test 7 Long lived secret clean up
+
+	// Create managed cluster namespace
+	c.Create(context.TODO(), test7ManagedClusterNamespace7)
+
+	// Create managed cluster
+	c.Create(context.TODO(), test7ManagedCluster7)
+
+	// Create Gitops namespace
+	c.Create(context.TODO(), test7GitopsServerNamespace7)
+
+	// Create Argo service
+	err = c.Create(context.TODO(), test7ArgoService)
+
+	// Create Gitops placement
+	c.Create(context.TODO(), test7GitopsPlacement)
+
+	// Creat Gitops placement decision
+	c.Create(context.TODO(), test7GitopsPlacementDecision)
+
+	g.Eventually(func(g2 gomega.Gomega) {
+		tempPlacementDecisionObject := expectedPlacementDecisionCreated(c,
+			types.NamespacedName{
+				Name:      test7GitopsPlacementDecision.Name,
+				Namespace: test7GitopsPlacementDecision.Namespace,
+			},
+		)
+
+		tempPlacementDecisionObject.Status = clusterv1beta1.PlacementDecisionStatus{
+			Decisions: []clusterv1beta1.ClusterDecision{
+				{
+					ClusterName: test7ManagedCluster7.Name,
+					Reason:      "",
+				},
+			},
+		}
+
+		g2.Expect(c.Status().Update(context.TODO(), tempPlacementDecisionObject)).Should(gomega.Succeed())
+	}, 60*time.Second, 1*time.Second).Should(gomega.Succeed())
+
+	// Create MSA
+	c.Create(context.TODO(), test7ManagedServiceAccount)
+
+	g.Eventually(func(g2 gomega.Gomega) {
+		updateManagedServiceAccount := expectedMSACreated(c, types.NamespacedName{
+			Name:      "application-manager",
+			Namespace: test7ManagedCluster7.Name,
+		})
+		test7etime := metav1.NewTime(time.Now().Add(1 * time.Hour))
+		updateManagedServiceAccount.Status = authv1beta1.ManagedServiceAccountStatus{
+			TokenSecretRef: &authv1beta1.SecretRef{
+				Name:                 "application-manager",
+				LastRefreshTimestamp: metav1.Now(),
+			},
+			ExpirationTimestamp: &test7etime,
+		}
+
+		g2.Expect(c.Status().Update(context.TODO(), updateManagedServiceAccount)).Should(gomega.Succeed())
+	}, 60*time.Second, 1*time.Second).Should(gomega.Succeed())
+
+	// Create managed cluster secret
+	c.Create(context.TODO(), test7ManagedClusterSecret)
+
+	// Create MSA secret
+	c.Create(context.TODO(), test7MSASecret)
+
+	// Create Gitops namespace cluster secret
+	c.Create(context.TODO(), test7GitopsNSSecret)
+
+	// Create GitopsCluster
+	c.Create(context.TODO(), test7GitopsCluster)
+
+	// Validate cluster secret is created in Gitops namespace
+	test7ClusterSecret := &corev1.Secret{}
+	g.Eventually(func(g2 gomega.Gomega) {
+		err = c.Get(context.TODO(), types.NamespacedName{
+			Name:      test7ManagedCluster7.Name + "-application-manager-cluster-secret",
+			Namespace: test7GitopsServerNamespace7.Name,
+		}, test7ClusterSecret)
+
+		g2.Expect(err).ToNot(gomega.BeNil())
+	}, 60*time.Second, 1*time.Second).Should(gomega.Succeed())
 }
 
 // test managed cluster secret creation for non OCP clusters
@@ -1177,6 +1414,48 @@ func expectedSecretCreated(c client.Client, expectedSecretKey types.NamespacedNa
 
 		if err == nil {
 			return secret
+		}
+
+		if timeout > 30 {
+			return nil
+		}
+
+		time.Sleep(time.Second * 3)
+
+		timeout += 3
+	}
+}
+
+func expectedMSACreated(c client.Client, expectedMSAKey types.NamespacedName) *authv1beta1.ManagedServiceAccount {
+	timeout := 0
+
+	for {
+		msa := &authv1beta1.ManagedServiceAccount{}
+		err := c.Get(context.TODO(), expectedMSAKey, msa)
+
+		if err == nil {
+			return msa
+		}
+
+		if timeout > 30 {
+			return nil
+		}
+
+		time.Sleep(time.Second * 3)
+
+		timeout += 3
+	}
+}
+
+func expectedPlacementDecisionCreated(c client.Client, expectedPlacementDecisionKey types.NamespacedName) *clusterv1beta1.PlacementDecision {
+	timeout := 0
+
+	for {
+		pd := &clusterv1beta1.PlacementDecision{}
+		err := c.Get(context.TODO(), expectedPlacementDecisionKey, pd)
+
+		if err == nil {
+			return pd
 		}
 
 		if timeout > 30 {

--- a/pkg/controller/gitopscluster/gitopscluster_controller_test.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller_test.go
@@ -1273,6 +1273,7 @@ func TestReconcileCreateSecretInOpenshiftGitops(t *testing.T) {
 
 	// Validate cluster secret is created in Gitops namespace
 	test7ClusterSecret := &corev1.Secret{}
+
 	g.Eventually(func(g2 gomega.Gomega) {
 		err = c.Get(context.TODO(), types.NamespacedName{
 			Name:      test7ManagedCluster7.Name + "-application-manager-cluster-secret",


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.

https://issues.redhat.com/browse/ACM-20496

- Reorganized the code for detecting ManagedServiceAccount
- Made error cases less aggressive in cleaning up the orphan cluster secret if the new cluster secret was not created successfully
- Clean up the old cluster secret only if the new one was created successfully

https://issues.redhat.com/browse/ACM-18755
- Just removes the backup label so the cluster secret doesn't get backed up. As Xiangjing mentioned in the jira since the secret only lives for 7 days it doesn't make sense to back it up because when the hub is restored the token in the secret may no longer be valid so I'm removing the backup label for all the cluster secrets no just local-cluster