### PR TITLE
ACM-18697 Change local-cluster cluster secret name

### DIFF
--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -1090,7 +1090,7 @@ func (r *ReconcileGitOpsCluster) CreateManagedClusterSecretInArgo(argoNamespace 
 				APIVersion: "v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      managedCluster.Name + clusterSecretSuffix,
+				Name:      managedCluster.Name + "-" + componentName + clusterSecretSuffix,
 				Namespace: argoNamespace,
 				Labels: map[string]string{
 					"argocd.argoproj.io/secret-type":                 "cluster",


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.

https://issues.redhat.com/browse/ACM-18697

- Change local-cluster cluster secret name to local-cluster-application-manager-cluster-secret