### PR TITLE
ACM-22418 Optimize the search api query

### DIFF
--- a/pkg/controller/gitopssyncresc/gitopssyncresc_controller.go
+++ b/pkg/controller/gitopssyncresc/gitopssyncresc_controller.go
@@ -326,6 +326,7 @@ func (r *GitOpsSyncResource) getArgoAppsFromSearch(clusters []string, appsetNs, 
 	// Build search body
 	kind := "Application"
 	apigroup := "argoproj.io"
+	label := "apps.open-cluster-management.io/application-set=true"
 	limit := int(-1)
 	searchInput := &model.SearchInput{
 		Filters: []*model.SearchFilter{
@@ -336,6 +337,10 @@ func (r *GitOpsSyncResource) getArgoAppsFromSearch(clusters []string, appsetNs, 
 			{
 				Property: "apigroup",
 				Values:   []*string{&apigroup},
+			},
+			{
+				Property: "label",
+				Values:   []*string{&label},
 			},
 			{
 				Property: "cluster",
@@ -356,7 +361,7 @@ func (r *GitOpsSyncResource) getArgoAppsFromSearch(clusters []string, appsetNs, 
 	searchQuery := make(map[string]interface{})
 	searchQuery["variables"] = searchVars
 
-	searchQuery["query"] = "query mySearch($input: [SearchInput]) {searchResult: search(input: $input) {items, related { kind count items }, count}}"
+	searchQuery["query"] = "query mySearch($input: [SearchInput]) {searchResult: search(input: $input) {items, related { kind items } }}"
 
 	postBody, _ := json.Marshal(searchQuery)
 	klog.V(1).Infof("search: %v", string(postBody[:]))


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/ACM-22418

### Problem
Some customers are observing very high load on search when Argo Applications are deployed in their environment.
This PR optimizes the search query to reduce the load on the search service.

### Changes
- Include label `apps.open-cluster-management.io/application-set=true` in the search query to reduce the amount of data returned. Apps that don't belong to an app set were being discarded when processing the response. This will discard them as part of the query. This should significantly reduce the number of relationships that search needs to compute.
- Remove `count` from the search request because it isn't used. We could also get count using len(items).


* [x] I have taken backward compatibility into consideration.


### Verification:

**Before:**
Many Argo applications were retrieved from search and then discarded.
```
I0814 19:48:22.332775 1 gitopssyncresc_controller.go:151] Start syncing gitops resources from search...
I0814 19:48:22.332874 1 gitopssyncresc_controller.go:289] Start getting argo application for cluster: [jorge-argo-managed], app: /
I0814 19:48:22.332919 1 gitopssyncresc_controller.go:319] search url: https://search-search-api.open-cluster-management.svc.cluster.local:4010/searchapi/graphql
I0814 19:48:23.122683 1 gitopssyncresc_controller.go:405] Finished getting argo application for cluster: [jorge-argo-managed], app: /
I0814 19:48:23.122709 1 gitopssyncresc_controller.go:194] skip application argocd/example.helm-dependency on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.122744 1 gitopssyncresc_controller.go:194] skip application argocd/example.sock-shop on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.122760 1 gitopssyncresc_controller.go:194] skip application argocd/example.plugin-nix on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.122770 1 gitopssyncresc_controller.go:194] skip application openshift-gitops/pacman-managed on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.122780 1 gitopssyncresc_controller.go:194] skip application openshift-gitops/jorge-pacman-01 on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.122788 1 gitopssyncresc_controller.go:194] skip application openshift-gitops/argo-pacman-01 on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.122798 1 gitopssyncresc_controller.go:194] skip application argocd/example.jsonnet-guestbook-tla on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.122813 1 gitopssyncresc_controller.go:207] report key: openshift-gitops_pacman-pull-model
I0814 19:48:23.122817 1 gitopssyncresc_controller.go:211] creating new report with key: openshift-gitops_pacman-pull-model
I0814 19:48:23.123229 1 gitopssyncresc_controller.go:234] resources for app (openshift-gitops/pacman-pull-model-jorge-argo-managed): [{v1 Service pacman pacman-pull-model} {v1 Service mongo pacman-pull-model} {v1 PersistentVolumeClaim mongo-storage pacman-pull-model} {apps/v1 Deployment mongo pacman-pull-model} {apps/v1 Deployment pacman pacman-pull-model} {route.openshift.io/v1 Route pacman pacman-pull-model} {route.openshift.io/v1 Route f5-gslb-pacman pacman-pull-model} {v1 PersistentVolume pvc-86475773-7ba9-4be0-8714-ea34da3ab73b }]
I0814 19:48:23.123260 1 gitopssyncresc_controller.go:194] skip application argocd/example.kustomize-guestbook on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.123270 1 gitopssyncresc_controller.go:194] skip application openshift-gitops/argo-pacman-aa on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.123279 1 gitopssyncresc_controller.go:194] skip application argocd/example.pre-post-sync on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.123289 1 gitopssyncresc_controller.go:194] skip application argocd/example.plugin-kustomized-helm on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.123299 1 gitopssyncresc_controller.go:194] skip application argocd/example.helm-guestbook on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.123307 1 gitopssyncresc_controller.go:194] skip application argocd/example.guestbook on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.123318 1 gitopssyncresc_controller.go:207] report key: openshift-gitops_argo-pacman
I0814 19:48:23.123321 1 gitopssyncresc_controller.go:211] creating new report with key: openshift-gitops_argo-pacman
I0814 19:48:23.123881 1 gitopssyncresc_controller.go:234] resources for app (openshift-gitops/argo-pacman-jorge-argo-managed): [{v1 Service pacman argo-dest-pacman} {v1 Service mongo argo-dest-pacman} {v1 PersistentVolumeClaim mongo-storage argo-dest-pacman} {apps/v1 Deployment mongo argo-dest-pacman} {apps/v1 Deployment pacman argo-dest-pacman} {route.openshift.io/v1 Route f5-gslb-pacman argo-dest-pacman} {route.openshift.io/v1 Route pacman argo-dest-pacman} {v1 PersistentVolume pvc-1ae5ff78-c09f-4e6f-8722-daa8e7854da6 }]
I0814 19:48:23.123908 1 gitopssyncresc_controller.go:194] skip application openshift-gitops/argo-sample-managed on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.123920 1 gitopssyncresc_controller.go:194] skip application argocd/example.blue-green on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.123929 1 gitopssyncresc_controller.go:194] skip application argocd/example.jsonnet-guestbook on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.123938 1 gitopssyncresc_controller.go:194] skip application argocd/example.helm-hooks on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.123948 1 gitopssyncresc_controller.go:194] skip application argocd/example.plugin-kasane on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.123958 1 gitopssyncresc_controller.go:194] skip application argocd/example.sync-waves on cluster jorge-argo-managed, it does not belong to an appset
I0814 19:48:23.124136 1 gitopssyncresc_controller.go:480] writing appset report: /etc/gitops-resources/openshift-gitops_pacman-pull-model.yaml
I0814 19:48:23.124518 1 gitopssyncresc_controller.go:480] writing appset report: /etc/gitops-resources/openshift-gitops_argo-pacman.yaml
I0814 19:48:23.124625 1 gitopssyncresc_controller.go:246] Finished syncing gitops resources from search
```

**After:**
None of the argo applications retrieved from search need to be discarded.
```
I0814 19:36:38.831280 1 gitopssyncresc_controller.go:151] Start syncing gitops resources from search...
I0814 19:36:38.831376 1 gitopssyncresc_controller.go:289] Start getting argo application for cluster: [jorge-argo-managed], app: /
I0814 19:36:38.831408 1 gitopssyncresc_controller.go:319] search url: https://search-search-api.open-cluster-management.svc.cluster.local:4010/searchapi/graphql
I0814 19:36:39.561278 1 gitopssyncresc_controller.go:410] Finished getting argo application for cluster: [jorge-argo-managed], app: /
I0814 19:36:39.561306 1 gitopssyncresc_controller.go:207] report key: openshift-gitops_pacman-pull-model
I0814 19:36:39.561312 1 gitopssyncresc_controller.go:211] creating new report with key: openshift-gitops_pacman-pull-model
I0814 19:36:39.561524 1 gitopssyncresc_controller.go:234] resources for app (openshift-gitops/pacman-pull-model-jorge-argo-managed): [{apps/v1 Deployment mongo pacman-pull-model} {apps/v1 Deployment pacman pacman-pull-model} {v1 PersistentVolume pvc-86475773-7ba9-4be0-8714-ea34da3ab73b } {v1 Service pacman pacman-pull-model} {v1 Service mongo pacman-pull-model} {v1 PersistentVolumeClaim mongo-storage pacman-pull-model} {route.openshift.io/v1 Route pacman pacman-pull-model} {route.openshift.io/v1 Route f5-gslb-pacman pacman-pull-model}]
I0814 19:36:39.561555 1 gitopssyncresc_controller.go:207] report key: openshift-gitops_argo-pacman
I0814 19:36:39.561560 1 gitopssyncresc_controller.go:211] creating new report with key: openshift-gitops_argo-pacman
I0814 19:36:39.561804 1 gitopssyncresc_controller.go:234] resources for app (openshift-gitops/argo-pacman-jorge-argo-managed): [{apps/v1 Deployment mongo argo-dest-pacman} {apps/v1 Deployment pacman argo-dest-pacman} {v1 PersistentVolume pvc-1ae5ff78-c09f-4e6f-8722-daa8e7854da6 } {v1 Service pacman argo-dest-pacman} {v1 Service mongo argo-dest-pacman} {v1 PersistentVolumeClaim mongo-storage argo-dest-pacman} {route.openshift.io/v1 Route f5-gslb-pacman argo-dest-pacman} {route.openshift.io/v1 Route pacman argo-dest-pacman}]
I0814 19:36:39.562043 1 gitopssyncresc_controller.go:485] writing appset report: /etc/gitops-resources/openshift-gitops_pacman-pull-model.yaml
I0814 19:36:39.562303 1 gitopssyncresc_controller.go:485] writing appset report: /etc/gitops-resources/openshift-gitops_argo-pacman.yaml
I0814 19:36:39.562386 1 gitopssyncresc_controller.go:246] Finished syncing gitops resources from search
```