### PR TITLE
[release-2.14] ACM-22418 Reduce search api request interval and make configurable

### DIFF
--- a/cmd/gitopssyncresc/exec/manager.go
+++ b/cmd/gitopssyncresc/exec/manager.go
@@ -97,7 +97,7 @@ func RunManager() {
 	}
 
 	// Setup all Controllers
-	if err := controller.AddGitOpsSyncRescToManager(mgr, options.SyncInterval, options.AppSetResourceDir); err != nil {
+	if err := controller.AddGitOpsSyncRescToManager(mgr, options.SyncInterval, options.AppSetResourceDir, options.SearchBatchSize, options.SearchSyncInterval); err != nil {
 		klog.Error(err, "")
 		os.Exit(1)
 	}

--- a/cmd/gitopssyncresc/exec/options.go
+++ b/cmd/gitopssyncresc/exec/options.go
@@ -23,6 +23,8 @@ import (
 // GitOpsClusterCMDOptions for command line flag parsing
 type GitOpsSyncRescCMDOptions struct {
 	MetricsAddr                 string
+	SearchBatchSize             int
+	SearchSyncInterval          int
 	SyncInterval                int
 	AppSetResourceDir           string
 	LeaderElectionLeaseDuration time.Duration
@@ -32,6 +34,8 @@ type GitOpsSyncRescCMDOptions struct {
 
 var options = GitOpsSyncRescCMDOptions{
 	MetricsAddr:                 "",
+	SearchBatchSize:             5,
+	SearchSyncInterval:          30,
 	SyncInterval:                10,
 	AppSetResourceDir:           "/var/appset-resc",
 	LeaderElectionLeaseDuration: 137 * time.Second,
@@ -48,6 +52,20 @@ func ProcessFlags() {
 		"metrics-addr",
 		options.MetricsAddr,
 		"The address the metric endpoint binds to.",
+	)
+
+	flag.IntVar(
+		&options.SearchBatchSize,
+		"search-batch-size",
+		options.SearchBatchSize,
+		"The max number of clusters in a single search query.",
+	)
+
+	flag.IntVar(
+		&options.SearchSyncInterval,
+		"search-sync-interval",
+		options.SearchSyncInterval,
+		"The interval for syncing gitops resources from search api in seconds.",
 	)
 
 	flag.IntVar(

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -23,7 +23,7 @@ var AddToManagerFuncs []func(manager.Manager) error
 
 var AddGitOpsClusterToManagerFuncs []func(manager.Manager) error
 
-var AddGitOpsSyncRescToManagerFuncs []func(manager.Manager, int, string) error
+var AddGitOpsSyncRescToManagerFuncs []func(manager.Manager, int, string, int, int) error
 
 // AddMulticlusterStatusAggregationToManagerFuncs is a list of functions to add all MulticlusterStatusAggregation Controllers to the Manager
 var AddMulticlusterStatusAggregationToManagerFuncs []func(manager.Manager, int, string) error
@@ -49,9 +49,9 @@ func AddGitOpsClusterToManager(m manager.Manager) error {
 	return nil
 }
 
-func AddGitOpsSyncRescToManager(m manager.Manager, interval int, resourceDir string) error {
+func AddGitOpsSyncRescToManager(m manager.Manager, interval int, resourceDir string, searchBatchSize int, searchSyncInterval int) error {
 	for _, f := range AddGitOpsSyncRescToManagerFuncs {
-		if err := f(m, interval, resourceDir); err != nil {
+		if err := f(m, interval, resourceDir, searchBatchSize, searchSyncInterval); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/gitopssyncresc/gitopssyncresc_controller_test.go
+++ b/pkg/controller/gitopssyncresc/gitopssyncresc_controller_test.go
@@ -176,9 +176,11 @@ func TestCreateOrUpdateAppSetReport(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	synResc := &GitOpsSyncResource{
-		Client:      nil,
-		Interval:    10,
-		ResourceDir: "/tmp",
+		Client:             nil,
+		Interval:           10,
+		SearchSyncInterval: 10,
+		SearchBatchSize:    5,
+		ResourceDir:        "/tmp",
 	}
 
 	appset1cluster1 := make(map[string]interface{})
@@ -321,9 +323,11 @@ func TestGitOpsSyncResource_getSearchURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := initClient()
 			r := &GitOpsSyncResource{
-				Client:      c,
-				Interval:    60,
-				ResourceDir: "/tmp",
+				Client:             c,
+				Interval:           60,
+				SearchSyncInterval: 60,
+				SearchBatchSize:    5,
+				ResourceDir:        "/tmp",
 			}
 
 			if tt.service != nil {
@@ -389,10 +393,12 @@ func TestGitOpsSyncResource_syncResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &GitOpsSyncResource{
-				Client:      c,
-				Interval:    60,
-				ResourceDir: "/tmp",
-				DataSender:  &TestDataSender{tt.data},
+				Client:             c,
+				Interval:           60,
+				SearchSyncInterval: 60,
+				SearchBatchSize:    5,
+				ResourceDir:        "/tmp",
+				DataSender:         &TestDataSender{tt.data},
 			}
 
 			if tt.managedcluster != nil {


### PR DESCRIPTION
Manual cherry-pick of #361 

Jira issue: https://issues.redhat.com/browse/ACM-22418

### Problem
Some customers are observing very high load on search when Argo Applications are deployed in their environment.
This PR is trying to reduce and optimize the requests to the search api. I don't expect this to completely solve the problem, but hoping it will help.

### Changes
- Increase the default search poll interval from 10 to 30s.
- Make configurable with arg `search-sync-interval`.
- Reduce the default number of clusters per search query from 20 to 5.
- Make configurable with arg `search-batch-size`.


## Verification
Reduction in search-postgres pod CPU consumption with this PR's image. Interval changed from 10s to 30s.
Increasing the interval to 60s did not produced a measurable change. This was tested on a very small deployment with 3 appsets.
<img width="1216" height="286" alt="image" src="https://github.com/user-attachments/assets/99c10a5c-cd60-4b73-a829-971c0c2067ec" />



* [ ] I have taken backward compatibility into consideration.

