### PR TITLE
source secret multicluster-operators-application-svc-ca not found in …

### DIFF
--- a/cmd/gitopscluster/exec/manager.go
+++ b/cmd/gitopscluster/exec/manager.go
@@ -368,7 +368,7 @@ func ensureArgoCDAgentCASecret(kubeClient client.Client) error {
 	sourceSecret := &v1.Secret{}
 	sourceSecretName := types.NamespacedName{
 		Name:      "multicluster-operators-application-svc-ca",
-		Namespace: "open-cluster-management",
+		Namespace: utils.GetComponentNamespace("open-cluster-management"),
 	}
 
 	err = kubeClient.Get(context.TODO(), sourceSecretName, sourceSecret)

--- a/gitopsaddon/gitopsaddon_controller.go
+++ b/gitopsaddon/gitopsaddon_controller.go
@@ -1037,7 +1037,7 @@ func (r *GitopsAddonReconciler) CreateUpdateNamespace(nameSpaceKey types.Namespa
 func (r *GitopsAddonReconciler) copyImagePullSecret(nameSpaceKey types.NamespacedName) error {
 	secretName := "open-cluster-management-image-pull-credentials"
 	secret := &corev1.Secret{}
-	gitopsAddonNs := utils.GetComponentNamespace()
+	gitopsAddonNs := utils.GetComponentNamespace("open-cluster-management-agent-addon")
 
 	// Get the original gitops addon image pull secret
 	err := r.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: gitopsAddonNs}, secret)

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -112,14 +112,14 @@ func CheckAndInstallCRD(crdconfig *rest.Config, pathname string) error {
 	return err
 }
 
-func GetComponentNamespace() string {
+func GetComponentNamespace(defaultNs string) string {
 	addonNameSpace := ""
 	nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 
 	if err != nil || len(nsBytes) == 0 {
 		klog.Errorf("failed to get gitops addon pod namespace. error: %v", err)
 
-		addonNameSpace = "open-cluster-management-agent-addon"
+		addonNameSpace = defaultNs
 	} else {
 		addonNameSpace = string(nsBytes)
 	}


### PR DESCRIPTION
…open-cluster-management namespace

* [X] I have taken backward compatibility into consideration.

https://issues.redhat.com/browse/ACM-23890

source secret multicluster-operators-application-svc-ca is created in the namespace where the pod multicluster-operators-application is running (MCH namespace). It could be in a namespace other than the default open-cluster-management namespace.
