### PR TITLE
Fix: Add localhost entries to ArgoCD agent certificates for local access

### DIFF
--- a/e2e-gitopsaddon/openshift-gitops/operator.yaml
+++ b/e2e-gitopsaddon/openshift-gitops/operator.yaml
@@ -396,6 +396,8 @@ spec:
         env:
         - name: ARGOCD_PRINCIPAL_TLS_SERVER_ALLOW_GENERATE
           value: "false"
+        - name: ARGOCD_PRINCIPAL_REDIS_SERVER_ADDRESS
+          value: "openshift-gitops-redis:6379"
         - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
           value: "*"
         - name: WATCH_NAMESPACE


### PR DESCRIPTION
This PR improves ArgoCD agent certificate generation by ensuring localhost entries are always included in TLS certificates, enabling local access even when external endpoints are not available.

## Changes Made

- **Certificate Generation**: Modified `discoverPrincipalEndpoints()` and `discoverResourceProxyEndpoints()` to always add localhost IPs (127.0.0.1, ::1) and DNS names (localhost, localhost.localdomain) to certificate SANs
- **Error Handling**: Changed behavior when no external endpoints are found - instead of failing with an error, the system now logs a warning and continues with localhost entries
- **Helper Function**: Added `contains()` utility function to check for string presence in slices
- **Configuration**: Added `ARGOCD_PRINCIPAL_REDIS_SERVER_ADDRESS` environment variable to operator configuration
- **Tests**: Updated test suite to verify localhost entries are properly included and added new test cases for the helper function
