### PR TITLE
Disable helm upgrades but allow installs in gitopsaddon controller

### DIFF
--- a/e2e-gitopsaddon/run_e2e-gitopsaddon.sh
+++ b/e2e-gitopsaddon/run_e2e-gitopsaddon.sh
@@ -52,10 +52,9 @@ kubectl patch networkpolicy openshift-gitops-redis-network-policy -n openshift-g
 kubectl patch networkpolicy acm-openshift-gitops-redis-network-policy -n openshift-gitops --context kind-cluster1 --type='json' -p='[{"op": "add", "path": "/spec/ingress/-", "value": {"ports": [{"port": 6379, "protocol": "TCP"}], "from": [{"podSelector": {"matchLabels": {"app.kubernetes.io/name": "argocd-agent-agent"}}}]}}]'
 kubectl rollout restart deployment openshift-gitops-agent-principal -n openshift-gitops --context kind-hub
 kubectl rollout restart deployment argocd-agent-agent -n openshift-gitops --context kind-cluster1
-sleep 30s
+sleep 90s
 kubectl config use-context kind-hub
 kubectl apply -f e2e-gitopsaddon/app.yaml
-sleep 30s
 
 # Validate hub
 kubectl config use-context kind-hub

--- a/gitopsaddon/gitopsaddon_controller.go
+++ b/gitopsaddon/gitopsaddon_controller.go
@@ -346,18 +346,9 @@ func (r *GitopsAddonReconciler) installOrUpgradeChart(configFlags *genericcliopt
 	}
 
 	if releaseExists {
-		// Release exists, do upgrade
-		helmUpgrade := action.NewUpgrade(actionConfig)
-		helmUpgrade.Namespace = namespace
-		helmUpgrade.Force = true // Enable force option for upgrades
-
-		_, err = helmUpgrade.Run(releaseName, chart, nil)
-
-		if err != nil {
-			return fmt.Errorf("failed to upgrade helm chart: %v/%v, err: %w", namespace, releaseName, err)
-		}
-
-		klog.Infof("Successfully upgraded helm chart: %v/%v", namespace, releaseName)
+		// DISABLED: Skip helm upgrades to prevent continuous secret generation
+		klog.Infof("Skipping helm upgrade for existing chart: %v/%v (upgrades disabled)", namespace, releaseName)
+		return nil
 	} else {
 		// delete stuck helm release secret if it exists
 		r.deleteHelmReleaseSecret(namespace, releaseName)


### PR DESCRIPTION
## Problem
The gitopsaddon controller was continuously performing helm upgrades, causing excessive helm secrets to be generated in the `openshift-gitops` namespace. This was happening because the controller would repeatedly upgrade existing helm releases.

## Solution
Modified the `installOrUpgradeChart` function to skip upgrades while preserving install functionality:
- When a helm release already exists: skip the upgrade and log a message
- When no helm release exists: perform the install as normal

## Benefits
- ✅ Initial installs work (operator, dependency, agent)
- ✅ Continuous upgrades prevented 
- ✅ No more excessive helm secret generation
- ✅ Minimal code change with clear intent
- ✅ Easy to re-enable upgrades in the future

This targeted fix addresses the root cause while maintaining essential functionality.