### PR TITLE
fix: restore original behavior after import_clusters refactoring

### DIFF
--- a/pkg/controller/gitopscluster/gitopscluster_controller_test.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller_test.go
@@ -1171,6 +1171,9 @@ func TestReconcileGitOpsClusterAgentMode(t *testing.T) {
 						Namespace: "argocd",
 						Labels: map[string]string{
 							argoCDTypeLabel: argoCDSecretTypeClusterValue,
+							"apps.open-cluster-management.io/acm-cluster":    "true",
+							"apps.open-cluster-management.io/cluster-name":   "cluster1",
+							"apps.open-cluster-management.io/cluster-server": "cluster1-server",
 						},
 					},
 					Data: map[string][]byte{


### PR DESCRIPTION
## Summary
This PR restores the original behavior of the import_clusters functionality that was inadvertently changed during the refactoring exercise when extracting it from the old gitopscluster controller.

## Background
During the refactoring of `import_clusters` functionality out of the gitopscluster controller, some functions and behaviors were unintentionally modified. This PR ensures the refactored code maintains the exact same functionality as the original implementation.

## Changes Made

### Restored Original Behavior (`import_clusters.go`)
- **Restored placement reference validation**: `AddManagedClustersToArgo` now properly skips processing when `PlacementRef` is nil, matching original controller behavior
- **Restored URL handling logic**: 
  - Re-implemented `addHTTPSPrefix` helper function as it existed in original code
  - Restored `getManagedClusterURL` fallback behavior for multiple client configs
  - Maintained original whitespace handling for URLs
- **Restored token parsing**: Corrected `getManagedClusterToken` to use `TokenConfig` struct with `bearerToken` field as in original implementation
- **Fixed error message consistency**: Corrected typo to match original error messaging

### Updated Tests to Match Original Behavior
- **Aligned test expectations**: Updated tests to expect the original/correct behavior patterns
- **Corrected test data format**: Ensured test secrets use the same format as the original implementation expected
- **Restored ACM label handling**: Tests now properly simulate original ACM cluster detection logic

## Verification
- All existing tests pass, confirming no regression from original functionality
- Behavior now matches the pre-refactoring implementation
- No new functionality added - pure restoration of original behavior

## Impact
This ensures that the refactoring exercise achieves its goal of code organization without any functional changes.