### PR TITLE
disable automatically set OverrideExistingConfigs to true when uninstall is true

### DIFF
--- a/e2e-gitopsaddon/run_e2e-gitopsaddon.sh
+++ b/e2e-gitopsaddon/run_e2e-gitopsaddon.sh
@@ -92,6 +92,7 @@ fi
 
 # Validate uninstall
 kubectl config use-context kind-hub
+kubectl patch gitopscluster gitopscluster -n openshift-gitops --type='merge' -p '{"spec":{"gitopsAddon":{"overrideExistingConfigs":true}}}'
 kubectl patch gitopscluster gitopscluster -n openshift-gitops --type='merge' -p '{"spec":{"gitopsAddon":{"uninstall":true}}}'
 sleep 120s
 kubectl config use-context kind-cluster1

--- a/pkg/controller/gitopscluster/addon_management.go
+++ b/pkg/controller/gitopscluster/addon_management.go
@@ -91,14 +91,9 @@ func (r *ReconcileGitOpsCluster) CreateAddOnDeploymentConfig(gitOpsCluster *gito
 		}
 
 		// Determine behavior based on overrideExistingConfigs setting
-		// Automatically set to true when uninstall is true
 		shouldOverrideExisting := false
-		if gitOpsCluster.Spec.GitOpsAddon != nil {
-			if gitOpsCluster.Spec.GitOpsAddon.Uninstall != nil && *gitOpsCluster.Spec.GitOpsAddon.Uninstall {
-				shouldOverrideExisting = true
-			} else if gitOpsCluster.Spec.GitOpsAddon.OverrideExistingConfigs != nil {
-				shouldOverrideExisting = *gitOpsCluster.Spec.GitOpsAddon.OverrideExistingConfigs
-			}
+		if gitOpsCluster.Spec.GitOpsAddon != nil && gitOpsCluster.Spec.GitOpsAddon.OverrideExistingConfigs != nil {
+			shouldOverrideExisting = *gitOpsCluster.Spec.GitOpsAddon.OverrideExistingConfigs
 		}
 
 		updatedVariables := make([]addonv1alpha1.CustomizedVariable, 0)


### PR DESCRIPTION
Disable automatically set OverrideExistingConfigs to true when uninstall is true 
so that it acts as a "double confirmation" that user wants to uninstall the gitopsaddon.