### PR TITLE
Fix ManifestWork namespace for ArgoCD agent CA on managed clusters

### DIFF
--- a/e2e-gitopsaddon/run_e2e-gitopsaddon.sh
+++ b/e2e-gitopsaddon/run_e2e-gitopsaddon.sh
@@ -61,7 +61,6 @@ kubectl patch deployment openshift-gitops-redis -n openshift-gitops --type='json
   }
 ]' --context kind-cluster1
 sleep 60s
-kubectl patch networkpolicy openshift-gitops-redis-network-policy -n openshift-gitops --context kind-hub --type='json' -p='[{"op": "add", "path": "/spec/ingress/-", "value": {"ports": [{"port": 6379, "protocol": "TCP"}], "from": [{"podSelector": {"matchLabels": {"app.kubernetes.io/name": "argocd-agent-principal"}}}]}}]'
 kubectl patch networkpolicy openshift-gitops-redis-network-policy -n openshift-gitops --context kind-cluster1 --type='json' -p='[{"op": "add", "path": "/spec/ingress/-", "value": {"ports": [{"port": 6379, "protocol": "TCP"}], "from": [{"podSelector": {"matchLabels": {"app.kubernetes.io/name": "argocd-agent-agent"}}}]}}]'
 kubectl rollout restart deployment openshift-gitops-agent-principal -n openshift-gitops --context kind-hub
 kubectl rollout restart deployment argocd-agent-agent -n openshift-gitops --context kind-cluster1


### PR DESCRIPTION
When creating ManifestWorks to deploy the ArgoCD agent CA certificate to managed clusters, the controller was using `Spec.ArgoServer.ArgoNamespace` (the hub's namespace) as the target namespace on managed clusters. This caused the `argocd-agent-ca` secret to be created in the wrong namespace on managed clusters when a custom GitOps namespace was configured via `Spec.GitOpsAddon.GitOpsNamespace`.

This PR fixes the namespace resolution by:

1. **Separating hub and managed cluster namespaces**: 
   - Hub namespace (`hubNamespace`): The namespace on the hub cluster where the CA certificate is read from (`Spec.ArgoServer.ArgoNamespace`)
   - Managed namespace (`managedNamespace`): The namespace on managed clusters where the secret will be created (`Spec.GitOpsAddon.GitOpsNamespace`)

2. **Respecting GitOpsAddon configuration**: The ManifestWork now correctly uses `Spec.GitOpsAddon.GitOpsNamespace` as the target namespace on managed clusters, falling back to `openshift-gitops` if not specified.

3. **Adding test coverage**: Added a new test case to verify that custom GitOps namespaces are properly respected when creating ManifestWorks.

- All existing unit tests pass with updated test cases
- New test case validates custom namespace behavior