### PR TITLE
Add Tekton pipelines for ACM 5.0

### DIFF
--- a/.tekton/multicloud-integrations-acm-50-pull-request.yaml
+++ b/.tekton/multicloud-integrations-acm-50-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-5.0"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      (target_branch == "main" || target_branch == "release-5.0")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-acm-50

--- a/.tekton/multicloud-integrations-acm-50-pull-request.yaml
+++ b/.tekton/multicloud-integrations-acm-50-pull-request.yaml
@@ -1,0 +1,65 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/multicloud-integrations?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "release-5.0"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-acm-50
+    appstudio.openshift.io/component: multicloud-integrations-acm-50
+    pipelines.appstudio.openshift.io/type: build
+  name: multicloud-integrations-acm-50-on-pull-request
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/multicloud-integrations-acm-50:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: dockerfile
+    value: build/Dockerfile.rhtap
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
+  - name: use-dev-package-managers
+    value: "true"
+  - name: enable-symlink-check
+    value: "false"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-multicloud-integrations-acm-50
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/multicloud-integrations-acm-50-push.yaml
+++ b/.tekton/multicloud-integrations-acm-50-push.yaml
@@ -7,8 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-5.0"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-acm-50

--- a/.tekton/multicloud-integrations-acm-50-push.yaml
+++ b/.tekton/multicloud-integrations-acm-50-push.yaml
@@ -1,0 +1,62 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/multicloud-integrations?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "release-5.0"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-acm-50
+    appstudio.openshift.io/component: multicloud-integrations-acm-50
+    pipelines.appstudio.openshift.io/type: build
+  name: multicloud-integrations-acm-50-on-push
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/multicloud-integrations-acm-50:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: dockerfile
+    value: build/Dockerfile.rhtap
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
+  - name: use-dev-package-managers
+    value: "true"
+  - name: enable-symlink-check
+    value: "false"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-multicloud-integrations-acm-50
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated build pipelines that run on pull requests (targeting main/release-5.0) and on push events, producing multi-platform container images.
  * Builds include image tagging for PRs/pushes, dependency prefetching and caching for faster builds, hermetic/source-image options, and automatic retention/expiry of build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->