### PR TITLE
chore: Mark MulticlusterApplicationSetReport v1alpha1 as deprecated via Kubernetes CRD deprecation convention

### DIFF
--- a/deploy/crds/apps.open-cluster-management.io_multiclusterapplicationsetreports.yaml
+++ b/deploy/crds/apps.open-cluster-management.io_multiclusterapplicationsetreports.yaml
@@ -17,7 +17,10 @@ spec:
     singular: multiclusterapplicationsetreport
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: apps.open-cluster-management.io/v1alpha1 MulticlusterApplicationSetReport
+      is deprecated and will be removed in a future release.
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/hack/crds/apps.open-cluster-management.io_multiclusterapplicationsetreports.yaml
+++ b/hack/crds/apps.open-cluster-management.io_multiclusterapplicationsetreports.yaml
@@ -17,7 +17,10 @@ spec:
     singular: multiclusterapplicationsetreport
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: apps.open-cluster-management.io/v1alpha1 MulticlusterApplicationSetReport
+      is deprecated and will be removed in a future release.
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/pkg/apis/appsetreport/v1alpha1/appsetreport_types.go
+++ b/pkg/apis/appsetreport/v1alpha1/appsetreport_types.go
@@ -25,6 +25,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope="Namespaced"
 // +kubebuilder:resource:shortName=appsetreport;appsetreports
+// +kubebuilder:deprecatedversion:warning="apps.open-cluster-management.io/v1alpha1 MulticlusterApplicationSetReport is deprecated and will be removed in a future release."
 type MulticlusterApplicationSetReport struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`


### PR DESCRIPTION
**INSTALLER CHANGES POST MERGE IS NEEDED**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * The `v1alpha1` API version of MulticlusterApplicationSetReport from the apps.open-cluster-management.io API group is now marked as deprecated. This version will be removed in a future release. Users should migrate to a newer API version to maintain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->