### PR TITLE
trims any trailing non-alphanumeric characters that would make the ap…

### DIFF
--- a/pkg/controller/gitopscluster/import_clusters.go
+++ b/pkg/controller/gitopscluster/import_clusters.go
@@ -497,7 +497,7 @@ func (r *ReconcileGitOpsCluster) tryManagedServiceAccountOption(
 				"argocd.argoproj.io/secret-type":                 "cluster",
 				"apps.open-cluster-management.io/acm-cluster":    "true",
 				"apps.open-cluster-management.io/cluster-name":   managedClusterName,
-				"apps.open-cluster-management.io/cluster-server": fmt.Sprintf("%.63s", strippedClusterURL),
+				"apps.open-cluster-management.io/cluster-server": truncateLabelValue(strippedClusterURL),
 				"apps.open-cluster-management.io/data-source":    "managed-service-account",
 			},
 		},
@@ -841,7 +841,7 @@ func (r *ReconcileGitOpsCluster) CreateManagedClusterSecretFromManagedServiceAcc
 				"argocd.argoproj.io/secret-type":                 "cluster",
 				"apps.open-cluster-management.io/acm-cluster":    "true",
 				"apps.open-cluster-management.io/cluster-name":   managedCluster.Name,
-				"apps.open-cluster-management.io/cluster-server": fmt.Sprintf("%.63s", strippedClusterURL),
+				"apps.open-cluster-management.io/cluster-server": truncateLabelValue(strippedClusterURL),
 			},
 		},
 		Type: "Opaque",
@@ -1169,7 +1169,7 @@ func (r *ReconcileGitOpsCluster) CreateManagedClusterSecretViaClusterProxy(
 				"argocd.argoproj.io/secret-type":                 "cluster",
 				"apps.open-cluster-management.io/acm-cluster":    "true",
 				"apps.open-cluster-management.io/cluster-name":   managedClusterName,
-				"apps.open-cluster-management.io/cluster-server": fmt.Sprintf("%.63s", strippedClusterURL),
+				"apps.open-cluster-management.io/cluster-server": truncateLabelValue(strippedClusterURL),
 				"apps.open-cluster-management.io/data-source":    "cluster-proxy",
 			},
 		},
@@ -1271,4 +1271,17 @@ func getManagedClusterURL(managedCluster *spokeclusterv1.ManagedCluster, token s
 
 	// If no URL was accessible, return the first URL as fallback
 	return firstURL, nil
+}
+
+// truncateLabelValue truncates a string to 63 characters (the Kubernetes label value limit) and
+// trims any trailing non-alphanumeric characters that would make the value invalid.
+// Kubernetes label values must start and end with an alphanumeric character.
+func truncateLabelValue(s string) string {
+	if len(s) > 63 {
+		s = s[:63]
+	}
+
+	return strings.TrimRightFunc(s, func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'))
+	})
 }

--- a/pkg/controller/gitopscluster/import_clusters_test.go
+++ b/pkg/controller/gitopscluster/import_clusters_test.go
@@ -2698,3 +2698,73 @@ func TestCreateManagedClusterSecretFromManagedServiceAccount(t *testing.T) {
 		})
 	}
 }
+
+func TestTruncateLabelValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "short value unchanged",
+			input:    "example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "exactly 63 chars ending with alphanumeric",
+			input:    "api.observability.stage.mastercard-uscentral-tst-az1.mks.cloud1",
+			expected: "api.observability.stage.mastercard-uscentral-tst-az1.mks.cloud1",
+		},
+		{
+			// Regression test: hostname longer than 63 chars whose 63-char prefix ends with '.'
+			// e.g. api.observability.stage.mastercard-uscentral-tst-az1.mks.cloud.zlocal
+			// truncated to 63 chars becomes "api.observability.stage.mastercard-uscentral-tst-az1.mks.cloud."
+			name:     "truncation produces trailing dot",
+			input:    "api.observability.stage.mastercard-uscentral-tst-az1.mks.cloud.zlocal",
+			expected: "api.observability.stage.mastercard-uscentral-tst-az1.mks.cloud",
+		},
+		{
+			name:     "truncation produces trailing dash",
+			input:    strings.Repeat("a", 62) + "-extra",
+			expected: strings.Repeat("a", 62),
+		},
+		{
+			name:     "truncation produces trailing underscore",
+			input:    strings.Repeat("a", 62) + "_extra",
+			expected: strings.Repeat("a", 62),
+		},
+		{
+			name:     "truncation produces trailing other non-alphanumeric character",
+			input:    strings.Repeat("a", 62) + "@extra",
+			expected: strings.Repeat("a", 62),
+		},
+		{
+			name:     "multiple trailing separators trimmed after truncation",
+			input:    strings.Repeat("a", 60) + "...extra",
+			expected: strings.Repeat("a", 60),
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "result never exceeds 63 chars",
+			input:    strings.Repeat("b", 70),
+			expected: strings.Repeat("b", 63),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateLabelValue(tt.input)
+			assert.Equal(t, tt.expected, got)
+			assert.LessOrEqual(t, len(got), 63, "label value must not exceed 63 characters")
+			if len(got) > 0 {
+				last := got[len(got)-1]
+				assert.True(t, (last >= 'a' && last <= 'z') || (last >= 'A' && last <= 'Z') || (last >= '0' && last <= '9'),
+					"label value must end with an alphanumeric character, got %q", string(last))
+			}
+		})
+	}
+}


### PR DESCRIPTION
…i server url label value invalid

https://redhat.atlassian.net/browse/ACM-33203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster server label generation to strictly enforce Kubernetes label rules (max 63 characters and a valid alphanumeric trailing character), preventing creation of malformed labels.

* **Tests**
  * Added comprehensive tests that validate label generation across multiple scenarios, including length limits and trimming of invalid trailing characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->