### PR TITLE
feat: Add autonomous agent mode support 

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,6 +82,8 @@ jobs:
             make_target: test-e2e-gitopsaddon-embedded-agent
           - scenario: olm-override
             make_target: test-e2e-gitopsaddon-olm-override
+          - scenario: embedded-autonomous
+            make_target: test-e2e-gitopsaddon-embedded-autonomous
     steps:
       - name: Free up disk space
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,11 +42,13 @@ make test-e2e
 make test-local-e2e-gitopsaddon-embedded
 make test-local-e2e-gitopsaddon-embedded-agent
 make test-local-e2e-gitopsaddon-olm-override
+make test-local-e2e-gitopsaddon-embedded-autonomous
 
 # Run gitopsaddon e2e tests on existing kind clusters (CI mode, no cluster creation)
 make test-e2e-gitopsaddon-embedded
 make test-e2e-gitopsaddon-embedded-agent
 make test-e2e-gitopsaddon-olm-override
+make test-e2e-gitopsaddon-embedded-autonomous
 
 # Run integration test scenarios against real ACM hub + managed clusters
 cd gitopsaddon && bash test-scenarios.sh all
@@ -129,6 +131,7 @@ Then run the local e2e tests (these create fresh Kind clusters, so they don't in
 make test-local-e2e-gitopsaddon-embedded
 make test-local-e2e-gitopsaddon-embedded-agent
 make test-local-e2e-gitopsaddon-olm-override
+make test-local-e2e-gitopsaddon-embedded-autonomous
 ```
 
 ## Architecture
@@ -169,6 +172,7 @@ The **gitopsaddon agent** (managed cluster) receives env vars from `AddOnDeploym
   - `test-scenarios.sh`: Integration test script for real ACM clusters
   - `README.md`: Comprehensive feature documentation
 - `deploy/crds/`: CRD definitions (GitOpsCluster, ArgoCD, etc.)
+- `docs/autonomous-mode-best-practices.md`: Best practices for bootstrapping autonomous mode with App of Apps pattern
 - `test/e2e/gitopsaddon/`: Ginkgo-based e2e tests (Kind clusters)
 
 ### Key CRDs
@@ -190,6 +194,7 @@ The **gitopsaddon agent** (managed cluster) receives env vars from `AddOnDeploym
 - **OLM Override**: `olmSubscription.enabled: true` in GitOpsCluster spec forces the addon to use OLM mode regardless of cluster type detection.
 - **Policy Recreation Control**: The controller recreates deleted Policies unless `skip-argocd-policy` annotation is set. When skipped, the `ArgoCDPolicyReady` condition is set to `True` with `Reason=Skipped` (not `Reason=Success`) so operators can distinguish intentional skips from actual readiness.
 - **Routes CRD Stub**: The repo ships a routes CRD at `gitopsaddon/routes-openshift-crd/routes.route.openshift.io.crd.yaml` with `served: false`. The gitopsaddon agent installs this on non-OCP managed clusters as part of the embedded Helm chart deployment. It is NOT installed by the e2e `setup_env.sh` — the upstream ArgoCD operator does not need it at all (it gracefully handles the absence: logs "route.openshift.io/v1 API is not registered" and skips Route creation, reconciling the ArgoCD CR fully to `Available`). The `served: false` flag prevents conflicts with ROSA HCP route API checks on real OCP clusters.
+- **Autonomous Agent Mode**: When `argoCDAgent.mode: "autonomous"` is set in the GitOpsCluster spec, agents run in autonomous mode instead of managed mode. Both modes reconcile Applications **locally** on the spoke via the ArgoCD application-controller — the key difference is the **source of truth**. In managed mode, the hub (principal) is the source of truth and dispatches Application specs to agents. In autonomous mode, the spoke is the source of truth — Applications are created directly on the managed cluster (via Git/Policy/kubectl), and the agent syncs specs and status back to the hub principal, which acts as a **read-only mirror** (users can inspect but cannot modify or delete autonomous apps via the hub UI/CLI/API). Key implementation details: (1) the `default` AppProject is included in the generated Policy (autonomous agents need it for local reconciliation), (2) Applications are typically deployed to the managed cluster via OCM Policy or Git (not via principal dispatch), (3) the `ARGOCD_AGENT_MODE=autonomous` env var is propagated to the addon agent via `AddOnDeploymentConfig`, which sets `spec.argoCDAgent.agent.client.mode: autonomous` in the ArgoCD CR, (4) AppProjects synced from autonomous agents are prefixed with the agent name on the hub (e.g., `default` becomes `ocp-cluster1-default`). Autonomous mode is the recommended pattern for App of Apps workflows where all ongoing changes flow through Git after initial bootstrap. See `docs/autonomous-mode-best-practices.md` for a comprehensive guide. Known limitation: autonomous mode on `local-cluster` (hub) has conflicts because the agent transforms Application specs (project name, destination) which fights with Policy enforcement. Reference: [argocd-agent docs](https://github.com/argoproj-labs/argocd-agent) — `docs/concepts/agent-modes/autonomous.md`, `docs/user-guide/applications.md`.
 
 ## Development Workflow
 
@@ -211,7 +216,7 @@ Runs against a real ACM hub + OCP managed cluster + Kind managed cluster. Enviro
 - `KIND_KUBECONFIG` — Kind cluster kubeconfig (default: `~/Desktop/kind-cluster1`)
 - `OCP_KUBECONFIG` — OCP cluster kubeconfig (default: `~/Desktop/ocp-cluster1`)
 
-Scenarios run sequentially: cleanup → S1 (no agent) → cleanup → S2 (agent) → S5 (drift heal, after S2) → cleanup → S3 (OLM, OCP only) → cleanup → S4 (OLM override, Kind)
+Scenarios run sequentially: cleanup → S1 (no agent) → cleanup → S2 (agent) → S5 (drift heal, after S2) → cleanup → S3 (OLM, OCP only) → cleanup → S4 (OLM override, Kind) → cleanup → S6 (autonomous agent)
 
 ### E2E Tests (Kind Clusters)
 The `make test-local-e2e-gitopsaddon-*` targets create fresh Kind clusters (`hub` + `cluster1`), install OCM, deploy the controller, and run Ginkgo tests. These use the upstream `argocd-operator` (not Red Hat/OLM) and test the embedded operator path. The e2e Kind clusters (`kind-hub`, `kind-cluster1`) are separate from any real managed clusters.
@@ -301,6 +306,7 @@ The GitHub Actions CI (`.github/workflows/e2e.yml`) runs on PRs to main/release 
 - **e2e-gitopsaddon (embedded)**: `make test-e2e-gitopsaddon-embedded` — tests non-agent addon flow + skip-argocd-policy annotation
 - **e2e-gitopsaddon (embedded-agent)**: `make test-e2e-gitopsaddon-embedded-agent` — tests agent mode flow + drift auto-heal + env var propagation
 - **e2e-gitopsaddon (olm-override)**: `make test-e2e-gitopsaddon-olm-override` — tests OLM override hub-side propagation
+- **e2e-gitopsaddon (embedded-autonomous)**: `make test-e2e-gitopsaddon-embedded-autonomous` — tests autonomous agent mode flow + Policy-based app deployment + local-cluster infrastructure verification
 
 To run locally what CI runs: `make test-local-e2e-gitopsaddon-embedded` (creates kind clusters, builds image, runs tests).
 

--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,10 @@ test-e2e-gitopsaddon-embedded-agent: manifests
 test-e2e-gitopsaddon-olm-override: manifests
 	$(call RUN_GITOPSADDON_E2E,olm-override)
 
+.PHONY: test-e2e-gitopsaddon-embedded-autonomous
+test-e2e-gitopsaddon-embedded-autonomous: manifests
+	$(call RUN_GITOPSADDON_E2E,embedded-autonomous)
+
 # --- Scenarios (Local) ---
 
 .PHONY: test-local-e2e-gitopsaddon-embedded
@@ -238,6 +242,11 @@ test-local-e2e-gitopsaddon-olm-override:
 	$(SETUP_KIND_CLUSTERS)
 	$(MAKE) test-e2e-gitopsaddon-olm-override
 
+.PHONY: test-local-e2e-gitopsaddon-embedded-autonomous
+test-local-e2e-gitopsaddon-embedded-autonomous:
+	$(SETUP_KIND_CLUSTERS)
+	$(MAKE) test-e2e-gitopsaddon-embedded-autonomous
+
 # --- Aggregate targets ---
 
 .PHONY: test-e2e-gitopsaddon-all
@@ -245,6 +254,7 @@ test-e2e-gitopsaddon-all:
 	$(MAKE) test-e2e-gitopsaddon-embedded
 	$(MAKE) test-e2e-gitopsaddon-embedded-agent
 	$(MAKE) test-e2e-gitopsaddon-olm-override
+	$(MAKE) test-e2e-gitopsaddon-embedded-autonomous
 
 .PHONY: clean-e2e
 clean-e2e:

--- a/deploy/crds/argoproj.io_argocds.yaml
+++ b/deploy/crds/argoproj.io_argocds.yaml
@@ -2122,18 +2122,21 @@ spec:
                   image:
                     description: Image is the Argo CD Notifications image (optional)
                     type: string
-                  logLevel:
-                    description: LogLevel describes the log level that should be used
-                      by the argocd-notifications. Defaults to ArgoCDDefaultLogLevel
-                      if not set.  Valid options are debug,info, error, and warn.
-                    type: string
-                  logformat:
+                  logFormat:
                     description: LogFormat refers to the log format used by the argocd-notifications.
                       Defaults to ArgoCDDefaultLogFormat if not configured. Valid
                       options are text or json.
                     enum:
                     - text
                     - json
+                    type: string
+                  logLevel:
+                    description: LogLevel describes the log level that should be used
+                      by the argocd-notifications. Defaults to ArgoCDDefaultLogLevel
+                      if not set.  Valid options are debug,info, error, and warn.
+                    type: string
+                  logformat:
+                    description: 'Deprecated: use LogFormat instead.'
                     type: string
                   replicas:
                     description: Replicas defines the number of replicas to run for
@@ -9143,18 +9146,21 @@ spec:
                       type: string
                     description: Custom labels to pods deployed by the operator
                     type: object
-                  logLevel:
-                    description: LogLevel describes the log level that should be used
-                      by the ApplicationSet controller. Defaults to ArgoCDDefaultLogLevel
-                      if not set.  Valid options are debug,info, error, and warn.
-                    type: string
-                  logformat:
+                  logFormat:
                     description: LogFormat refers to the log format used by the ApplicationSet
                       component. Defaults to ArgoCDDefaultLogFormat if not configured.
                       Valid options are text or json.
                     enum:
                     - text
                     - json
+                    type: string
+                  logLevel:
+                    description: LogLevel describes the log level that should be used
+                      by the ApplicationSet controller. Defaults to ArgoCDDefaultLogLevel
+                      if not set.  Valid options are debug,info, error, and warn.
+                    type: string
+                  logformat:
+                    description: 'Deprecated: use LogFormat instead.'
                     type: string
                   resources:
                     description: Resources defines the Compute Resources required
@@ -18281,18 +18287,21 @@ spec:
                   image:
                     description: Image is the Argo CD Notifications image (optional)
                     type: string
-                  logLevel:
-                    description: LogLevel describes the log level that should be used
-                      by the argocd-notifications. Defaults to ArgoCDDefaultLogLevel
-                      if not set.  Valid options are debug,info, error, and warn.
-                    type: string
-                  logformat:
+                  logFormat:
                     description: LogFormat refers to the log format used by the argocd-notifications.
                       Defaults to ArgoCDDefaultLogFormat if not configured. Valid
                       options are text or json.
                     enum:
                     - text
                     - json
+                    type: string
+                  logLevel:
+                    description: LogLevel describes the log level that should be used
+                      by the argocd-notifications. Defaults to ArgoCDDefaultLogLevel
+                      if not set.  Valid options are debug,info, error, and warn.
+                    type: string
+                  logformat:
+                    description: 'Deprecated: use LogFormat instead.'
                     type: string
                   replicas:
                     description: Replicas defines the number of replicas to run for

--- a/gitopsaddon/README.md
+++ b/gitopsaddon/README.md
@@ -11,7 +11,7 @@ This guide explains how to configure and test the GitOps Addon functionality usi
 - **Cluster Secrets**: For agent mode, the controller creates ArgoCD cluster secrets with proper server URLs including `agentName` query parameter
 - **DISABLE_DEFAULT_ARGOCD_INSTANCE**: On OCP managed clusters, the addon creates an OLM Subscription with `DISABLE_DEFAULT_ARGOCD_INSTANCE=true`. On non-OCP clusters, the embedded operator chart is deployed. On the hub (`local-cluster`), the operator is already present so no installation occurs.
 - **OLM Subscription Override**: When `olmSubscription.enabled: true` is set in the GitOpsCluster spec, the addon agent is **forced** to use OLM subscription mode for operator installation, bypassing OCP auto-detection. This ensures OLM is used even if the cluster detection fails or the cluster is non-OCP (though OLM must be available on the cluster for the installation to succeed). Custom subscription values (channel, source, namespace, etc.) are passed to the addon agent via `AddOnDeploymentConfig` environment variables. When absent or disabled, the agent falls back to OCP auto-detection and uses hardcoded defaults (`channel: latest`, `source: redhat-operators`, etc.).
-- **AppProject Propagation (Agent Mode)**: In agent mode, the ArgoCD principal automatically propagates AppProjects from the hub to managed clusters. The `default` AppProject is created on the hub in the managed cluster's namespace alongside the Application.
+- **AppProject Propagation (Agent Mode)**: In managed agent mode, the ArgoCD principal propagates AppProjects from the hub to managed clusters. In autonomous agent mode, AppProjects are created locally on the spoke and synced back to the hub with the agent name prefixed (e.g., `default` becomes `ocp-cluster1-default`). The `default` AppProject is included in the generated Policy for autonomous mode to ensure local reconciliation works before any agent sync occurs.
 - **Destination-Based Mapping (Agent Architecture)**: The principal keeps `destinationBasedMapping: true` for **routing** — it dispatches Applications to agents based on `spec.destination.name`. The **agents** have `destinationBasedMapping` disabled (not set in the ArgoCD CR). This is critical for `local-cluster`: the agent's `getTargetNamespaceForApp()` returns its own namespace (`local-cluster`), so agent-created Application copies go to the `local-cluster` namespace where the app controller watches. For remote clusters (Kind/OCP), the agent's namespace IS `openshift-gitops`, so the behavior is identical whether DBM is enabled or disabled on the agent. If agent DBM were enabled, the agent would keep the original namespace (`openshift-gitops`) from the hub — this fails on `local-cluster` because the app controller runs in `local-cluster`, not `openshift-gitops`, and it conflicts with existing ApplicationSet-generated apps in `openshift-gitops`.
 - **Image Pull Secret Handling**: Two mechanisms work together:
   1. **Secret copying (OCM klusterlet)**: The addon agent labels namespaces it creates (`openshift-gitops-operator`, `openshift-gitops`) with `addon.open-cluster-management.io/namespace: true`. This label tells the OCM klusterlet to automatically copy the `open-cluster-management-image-pull-credentials` secret into those namespaces. No custom propagation code is needed for this step.
@@ -58,6 +58,7 @@ All scenarios target `local-cluster` (hub), `ocp-cluster1` (OCP), and `kind-clus
 | **3** | Custom OLM | OCP only | N/A (validates OLM config) | installPlanApproval=Manual, DISABLE_DEFAULT_ARGOCD_INSTANCE=true, no embedded operator |
 | **4** | OLM Override on Kind | Kind only | N/A (validates OLM override) | olmSubscription.enabled forces OLM mode on Kind (no OCP auto-detect), agent attempts OLM subscription (fails gracefully since no OLM on Kind) |
 | **5** | Agent Version Drift Heal | All (runs after S2) | N/A (validates drift heal) | Simulates principal image drift, verifies controller patches ArgoCD Policy agent image, verifies restore after drift correction |
+| **6** | Autonomous Agent Mode | OCP + Kind + local-cluster | Policy deploys guestbook Application to spokes | Agents in autonomous mode, local reconciliation, status synced back to hub, AppProject included in Policy |
 
 **Notes:**
 - On OCP, guestbook-ui pods **crash** due to OCP's `restricted-v2` SCC (port 80 binding). The test checks that the Deployment resource exists (ArgoCD synced it), not pod health. On Kind, pods run normally.
@@ -468,6 +469,178 @@ KUBECONFIG=/path/to/managed kubectl get pods -n guestbook
 
 ---
 
+## Scenario 6: Autonomous Mode
+
+In autonomous mode, ArgoCD agents run on managed clusters and connect to the hub principal. Both managed and autonomous modes reconcile Applications **locally on the spoke** via the ArgoCD application-controller — the key difference is the **source of truth**. In managed mode, the hub is the source of truth and dispatches Application specs to agents. In autonomous mode, the spoke is the source of truth — Applications are created on the managed cluster (via Policy, Git, or `kubectl`), and the agent syncs both specs and status back to the hub principal, which acts as a **read-only mirror** (cannot modify or delete autonomous apps). This is the recommended pattern for the **App of Apps** bootstrap workflow. See `docs/autonomous-mode-best-practices.md` for a comprehensive guide.
+
+> **Source**: Mode definitions verified against [argocd-agent](https://github.com/argoproj-labs/argocd-agent) docs — `docs/concepts/agent-modes/autonomous.md`, `docs/concepts/agent-modes/managed.md`, `docs/user-guide/applications.md`.
+
+### Key Differences from Managed Mode
+
+| Aspect | Managed Mode | Autonomous Mode |
+|--------|-------------|-----------------|
+| Source of truth | Hub (principal) | Spoke (workload cluster) |
+| Application creation | On the hub; principal dispatches to agents | On the managed cluster (via Policy, Git, or `kubectl`) |
+| Application reconciliation | Local on spoke (same as autonomous) | Local on spoke; agent syncs specs+status to hub |
+| Hub capability | Full control — create, modify, delete apps | Read-only mirror — inspect only, no modifications |
+| Spoke drift | Reverted by agent to match hub spec | N/A — spoke owns the spec |
+| AppProject on hub | Original name | Prefixed with agent name (e.g., `ocp-cluster1-default`) |
+| AppProject in Policy | Not included (principal propagates) | Included (needed for local reconciliation) |
+| Best for | Centralized control | App of Apps, GitOps-first, edge/air-gap |
+
+### Step 1: Create GitOpsCluster with Autonomous Mode
+
+```bash
+export KUBECONFIG=/path/to/hub/kubeconfig
+
+# Create Placement
+cat <<EOF | kubectl apply -f -
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: autonomous-placement
+  namespace: openshift-gitops
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            name: my-managed-cluster
+EOF
+
+# Create GitOpsCluster with autonomous mode
+cat <<EOF | kubectl apply -f -
+apiVersion: apps.open-cluster-management.io/v1beta1
+kind: GitOpsCluster
+metadata:
+  name: autonomous-gitops
+  namespace: openshift-gitops
+spec:
+  argoServer:
+    cluster: local-cluster
+    argoNamespace: openshift-gitops
+  placementRef:
+    kind: Placement
+    apiVersion: cluster.open-cluster-management.io/v1beta1
+    name: autonomous-placement
+  gitopsAddon:
+    enabled: true
+    argoCDAgent:
+      enabled: true
+      mode: autonomous
+EOF
+```
+
+### Step 2: Modify Policy to Add RBAC and Bootstrap Application
+
+In autonomous mode, the Application is deployed to the managed cluster via the Policy. The `default` AppProject is automatically included in the Policy (unlike managed mode where the principal propagates it).
+
+```bash
+# Wait for the Policy to be created
+kubectl get policy autonomous-gitops-argocd-policy -n openshift-gitops
+
+# Add RBAC and a root Application (e.g., for App of Apps pattern)
+kubectl patch policy autonomous-gitops-argocd-policy -n openshift-gitops --type=json -p='[
+  {
+    "op": "add",
+    "path": "/spec/policy-templates/-",
+    "value": {
+      "objectDefinition": {
+        "apiVersion": "policy.open-cluster-management.io/v1",
+        "kind": "ConfigurationPolicy",
+        "metadata": {
+          "name": "autonomous-gitops-argocd-policy-rbac"
+        },
+        "spec": {
+          "remediationAction": "enforce",
+          "severity": "medium",
+          "object-templates": [
+            {
+              "complianceType": "musthave",
+              "objectDefinition": {
+                "apiVersion": "rbac.authorization.k8s.io/v1",
+                "kind": "ClusterRoleBinding",
+                "metadata": {
+                  "name": "acm-openshift-gitops-cluster-admin"
+                },
+                "roleRef": {
+                  "apiGroup": "rbac.authorization.k8s.io",
+                  "kind": "ClusterRole",
+                  "name": "cluster-admin"
+                },
+                "subjects": [
+                  {
+                    "kind": "ServiceAccount",
+                    "name": "acm-openshift-gitops-argocd-application-controller",
+                    "namespace": "openshift-gitops"
+                  }
+                ]
+              }
+            },
+            {
+              "complianceType": "musthave",
+              "objectDefinition": {
+                "apiVersion": "argoproj.io/v1alpha1",
+                "kind": "Application",
+                "metadata": {
+                  "name": "app-of-apps-root",
+                  "namespace": "openshift-gitops"
+                },
+                "spec": {
+                  "project": "default",
+                  "source": {
+                    "repoURL": "https://github.com/YOUR-ORG/YOUR-GITOPS-REPO",
+                    "targetRevision": "HEAD",
+                    "path": "apps"
+                  },
+                  "destination": {
+                    "server": "https://kubernetes.default.svc",
+                    "namespace": "openshift-gitops"
+                  },
+                  "syncPolicy": {
+                    "automated": {
+                      "prune": true,
+                      "selfHeal": true
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+]'
+```
+
+### Step 3: Verify Autonomous Mode
+
+```bash
+# Verify agent mode is set to autonomous in AddOnDeploymentConfig
+kubectl get addondeploymentconfig gitops-addon-config -n <managed-cluster> \
+  -o jsonpath='{.spec.customizedVariables[?(@.name=="ARGOCD_AGENT_MODE")].value}'
+# Expected: autonomous
+
+# Verify ArgoCD CR on managed cluster has autonomous client mode
+KUBECONFIG=/path/to/managed kubectl get argocd acm-openshift-gitops -n openshift-gitops \
+  -o jsonpath='{.spec.argoCDAgent.agent.client.mode}'
+# Expected: autonomous
+
+# Verify agent pod is running and syncing status back to hub
+KUBECONFIG=/path/to/managed kubectl logs -n openshift-gitops -l app.kubernetes.io/part-of=argocd-agent --tail=10
+# Look for: "Updated application status" messages (agent syncing back to principal)
+
+# Verify Applications are reconciled locally on managed cluster
+KUBECONFIG=/path/to/managed kubectl get applications.argoproj.io -n openshift-gitops -o wide
+```
+
+### Known Limitations
+
+- **Local-cluster (hub)**: In autonomous mode on `local-cluster`, the agent transforms Application specs (project name gets namespace-prefixed, destination gets cluster name reference), which can conflict with the Policy that enforces the original spec. Autonomous mode is primarily designed for remote managed clusters, not the hub itself. For hub-local Applications, use non-agent mode or managed agent mode.
+
+---
+
 ## Cleanup
 
 All cleanup operations are performed from the hub cluster. **The order matters** — see `argocd_policy.go` for the canonical reference.
@@ -550,6 +723,7 @@ These tests run against Kind clusters and are used for both GitHub PR CI and loc
 | `test-local-e2e-gitopsaddon-embedded` | `embedded` | Non-agent mode: spoke + local-cluster get ArgoCD via embedded operator, guestbook deploys and syncs on both, skip-argocd-policy annotation |
 | `test-local-e2e-gitopsaddon-embedded-agent` | `embedded-agent` | Agent mode: spoke gets agent pod, ApplicationSet deploys guestbook via principal/agent, local-cluster MCA/ArgoCD verified, agent version drift auto-heal |
 | `test-local-e2e-gitopsaddon-olm-override` | `olm-override` | OLM override: validates `olmSubscription.enabled=true` propagates `OLM_SUBSCRIPTION_ENABLED=true` to AddOnDeploymentConfig |
+| `test-local-e2e-gitopsaddon-embedded-autonomous` | `embedded-autonomous` | Autonomous mode: spoke gets agent in autonomous mode, guestbook deployed via Policy, local reconciliation, status synced to hub, local-cluster infrastructure verified |
 
 **Local development (creates Kind clusters + runs tests):**
 
@@ -604,6 +778,7 @@ make test-e2e-gitopsaddon-all
 - `test/e2e/gitopsaddon/helpers_test.go` — YAML generators, wait helpers, verification, cleanup
 - `test/e2e/gitopsaddon/gitopsaddon_embedded_test.go` — embedded (non-agent) scenario
 - `test/e2e/gitopsaddon/gitopsaddon_embedded_agent_test.go` — embedded + agent scenario
+- `test/e2e/gitopsaddon/gitopsaddon_embedded_autonomous_test.go` — embedded + autonomous agent scenario
 - `test/e2e/gitopsaddon/scripts/setup_env.sh` — environment setup (OCM, ArgoCD, controller)
 - `test/e2e/fixtures/` — ArgoCD operator CRDs and deployment YAML
 - `gitopsaddon/routes-openshift-crd/routes.route.openshift.io.crd.yaml` — Route CRD stub with `served: false`, installed by the gitopsaddon agent on non-OCP managed clusters as part of the embedded chart. NOT applied by `setup_env.sh` — the upstream ArgoCD operator does not need it (gracefully handles absent Route API, reconciles ArgoCD CR to `Available` without it).
@@ -635,6 +810,7 @@ export OCP_CLUSTER_NAME=ocp-cluster1
 ./gitopsaddon/test-scenarios.sh 3  # Custom OLM (OCP only)
 ./gitopsaddon/test-scenarios.sh 4  # OLM Override on Kind (Kind only)
 ./gitopsaddon/test-scenarios.sh 5  # Agent Version Drift Heal (deploys S2 first)
+./gitopsaddon/test-scenarios.sh 6  # Autonomous Agent Mode (OCP + Kind + local-cluster)
 
 # Cleanup only
 ./gitopsaddon/test-scenarios.sh cleanup

--- a/gitopsaddon/test-scenarios.sh
+++ b/gitopsaddon/test-scenarios.sh
@@ -19,6 +19,10 @@
 #   Validates that the hub controller detects principal image drift and patches
 #   the ArgoCD Policy's agent image field. Runs after Scenario 2 deployment.
 #
+# Scenario 6: Autonomous Agent Mode - All 3 clusters
+#   Agent mode with mode=autonomous: Applications created on managed clusters via
+#   Policy, ArgoCD agent syncs status back to hub principal.
+#
 # Key Design Principles:
 # - All operations performed from the hub cluster (simulates user experience)
 # - RBAC is created by modifying the Policy that GitOpsCluster generates
@@ -27,9 +31,9 @@
 # - Between-scenario cleanup is hub-triggered only
 #
 # IMPORTANT: Scenarios run sequentially. Each depends on clean state.
-# The "all" mode runs: cleanup → S1 → cleanup → S2 → S5 → cleanup → S3 → cleanup → S4 → cleanup
+# The "all" mode runs: cleanup → S1 → cleanup → S2 → S5 → cleanup → S3 → cleanup → S4 → cleanup → S6 → cleanup
 #
-# Usage: ./test-scenarios.sh [1|2|3|4|5|all|cleanup]
+# Usage: ./test-scenarios.sh [1|2|3|4|5|6|all|cleanup]
 #
 # Environment Variables:
 #   HUB_KUBECONFIG      - Hub cluster kubeconfig (default: ~/Desktop/hub)
@@ -2739,6 +2743,362 @@ except:
 }
 
 #######################################
+# SCENARIO 6: Autonomous Agent Mode
+# Validates agent mode with autonomous (apps created on managed cluster via Policy,
+# synced back to hub by argocd-agent)
+#######################################
+test_scenario_6() {
+    log_info "=============================================="
+    log_info "SCENARIO 6: Autonomous Agent Mode"
+    log_info "=============================================="
+    log_info "  - Same agent infrastructure as Scenario 2 (principal on hub)"
+    log_info "  - GitOpsCluster with mode: autonomous"
+    log_info "  - Applications delivered via Policy (created on managed cluster)"
+    log_info "  - Agent syncs Application status back to hub"
+    log_info "=============================================="
+
+    export KUBECONFIG=$HUB_KUBECONFIG
+
+    configure_hub_argocd_agent
+    ensure_clusterset_binding
+    ensure_addon_template
+    ensure_default_appproject_for_agents
+
+    # Build cluster list based on OCP availability
+    local placement_clusters=("$KIND_CLUSTER_NAME" "$LOCAL_CLUSTER_NAME")
+    if [ "$HAS_OCP" = true ]; then
+        placement_clusters=("$OCP_CLUSTER_NAME" "${placement_clusters[@]}")
+    else
+        log_warn "OCP cluster not available — running scenario 6 with Kind + local-cluster only"
+    fi
+
+    local placement_values=""
+    for c in "${placement_clusters[@]}"; do
+        placement_values="${placement_values}
+                - $c"
+    done
+
+    log_info "Creating Placement (${placement_clusters[*]})..."
+    cat <<EOF | kubectl apply -f -
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: all-autonomous-placement
+  namespace: openshift-gitops
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: name
+              operator: In
+              values:${placement_values}
+EOF
+
+    log_info "Creating GitOpsCluster (autonomous agent mode)..."
+    cat <<EOF | kubectl apply -f -
+apiVersion: apps.open-cluster-management.io/v1beta1
+kind: GitOpsCluster
+metadata:
+  name: all-autonomous-gitops
+  namespace: openshift-gitops
+spec:
+  argoServer:
+    cluster: local-cluster
+    argoNamespace: openshift-gitops
+  placementRef:
+    kind: Placement
+    apiVersion: cluster.open-cluster-management.io/v1beta1
+    name: all-autonomous-placement
+  gitopsAddon:
+    enabled: true
+    argoCDAgent:
+      enabled: true
+      mode: autonomous
+EOF
+
+    # Wait for ManagedClusterAddOns
+    if [ "$HAS_OCP" = true ]; then
+        wait_for_condition 300 "ManagedClusterAddOn for $OCP_CLUSTER_NAME" \
+            "kubectl get managedclusteraddon gitops-addon -n $OCP_CLUSTER_NAME -o name" || return 1
+    fi
+    wait_for_condition 300 "ManagedClusterAddOn for $KIND_CLUSTER_NAME" \
+        "kubectl get managedclusteraddon gitops-addon -n $KIND_CLUSTER_NAME -o name" || return 1
+    wait_for_condition 300 "ManagedClusterAddOn for $LOCAL_CLUSTER_NAME" \
+        "kubectl get managedclusteraddon gitops-addon -n $LOCAL_CLUSTER_NAME -o name" || return 1
+
+    # Add RBAC and guestbook Application to the Policy.
+    # In autonomous mode, the Application is created on the managed cluster via Policy.
+    # The ArgoCD instance on the managed cluster reconciles it locally.
+    add_rbac_and_app_to_policy "all-autonomous-gitops-argocd-policy" "openshift-gitops" || return 1
+
+    # Wait for Policy to be compliant
+    wait_for_policy_compliant "all-autonomous-gitops-argocd-policy" "openshift-gitops" 420 || return 1
+
+    # Verify ARGOCD_AGENT_MODE=autonomous in AddOnDeploymentConfig
+    log_info "Verifying ARGOCD_AGENT_MODE=autonomous in AddOnDeploymentConfig..."
+    if [ "$HAS_OCP" = true ]; then
+        wait_for_condition 60 "ARGOCD_AGENT_MODE=autonomous for $OCP_CLUSTER_NAME" \
+            "kubectl get addondeploymentconfig gitops-addon-config -n $OCP_CLUSTER_NAME -o jsonpath='{.spec.customizedVariables[?(@.name==\"ARGOCD_AGENT_MODE\")].value}' 2>/dev/null | grep -qx 'autonomous'" || {
+                log_error "SCENARIO 6: ARGOCD_AGENT_MODE not autonomous for $OCP_CLUSTER_NAME"
+                kubectl get addondeploymentconfig gitops-addon-config -n $OCP_CLUSTER_NAME -o yaml 2>/dev/null || true
+                return 1
+            }
+        log_info "  ARGOCD_AGENT_MODE=autonomous for $OCP_CLUSTER_NAME: OK"
+    fi
+    wait_for_condition 60 "ARGOCD_AGENT_MODE=autonomous for $KIND_CLUSTER_NAME" \
+        "kubectl get addondeploymentconfig gitops-addon-config -n $KIND_CLUSTER_NAME -o jsonpath='{.spec.customizedVariables[?(@.name==\"ARGOCD_AGENT_MODE\")].value}' 2>/dev/null | grep -qx 'autonomous'" || {
+            log_error "SCENARIO 6: ARGOCD_AGENT_MODE not autonomous for $KIND_CLUSTER_NAME"
+            return 1
+        }
+    log_info "  ARGOCD_AGENT_MODE=autonomous for $KIND_CLUSTER_NAME: OK"
+
+    # Verify OLM auto-detected on OCP (if available)
+    if [ "$HAS_OCP" = true ]; then
+        verify_olm_auto_detected "$OCP_KUBECONFIG" "$OCP_CLUSTER_NAME" || return 1
+    fi
+
+    # Wait for ArgoCD agent pods
+    if [ "$HAS_OCP" = true ]; then
+        wait_for_condition 900 "ArgoCD agent on $OCP_CLUSTER_NAME" \
+            "KUBECONFIG=$OCP_KUBECONFIG kubectl get pods -n openshift-gitops -l app.kubernetes.io/part-of=argocd-agent -o name | grep -q pod" || {
+                log_error "SCENARIO 6: ArgoCD agent pod not running on $OCP_CLUSTER_NAME"
+                KUBECONFIG=$OCP_KUBECONFIG kubectl get pods -n openshift-gitops --no-headers 2>/dev/null || true
+                KUBECONFIG=$OCP_KUBECONFIG kubectl get argocd -n openshift-gitops -o yaml 2>/dev/null || true
+                return 1
+            }
+    fi
+    wait_for_condition 600 "ArgoCD agent on $KIND_CLUSTER_NAME" \
+        "KUBECONFIG=$KIND_KUBECONFIG kubectl get pods -n openshift-gitops -l app.kubernetes.io/part-of=argocd-agent -o name | grep -q pod" || {
+            log_error "SCENARIO 6: ArgoCD agent pod not running on $KIND_CLUSTER_NAME"
+            KUBECONFIG=$KIND_KUBECONFIG kubectl get pods -n openshift-gitops --no-headers 2>/dev/null || true
+            return 1
+        }
+    wait_for_condition 600 "ArgoCD agent on $LOCAL_CLUSTER_NAME" \
+        "kubectl get pods -n local-cluster -l app.kubernetes.io/part-of=argocd-agent -o name | grep -q pod" || {
+            log_error "SCENARIO 6: ArgoCD agent pod not running on $LOCAL_CLUSTER_NAME"
+            kubectl get pods -n local-cluster --no-headers 2>/dev/null || true
+            return 1
+        }
+
+    # Verify agents connected
+    if [ "$HAS_OCP" = true ]; then
+        verify_agent_connected "$OCP_CLUSTER_NAME" || return 1
+    fi
+    verify_agent_connected "$KIND_CLUSTER_NAME" || return 1
+    verify_agent_connected "$LOCAL_CLUSTER_NAME" || return 1
+
+    # Wait for ArgoCD app controller to be running (autonomous mode needs local app controller)
+    if [ "$HAS_OCP" = true ]; then
+        wait_for_condition 900 "ArgoCD app controller on $OCP_CLUSTER_NAME" \
+            "KUBECONFIG=$OCP_KUBECONFIG kubectl get pods -n openshift-gitops -l app.kubernetes.io/name=acm-openshift-gitops-application-controller --field-selector=status.phase=Running --no-headers 2>/dev/null | grep -q Running" || {
+                log_error "SCENARIO 6: ArgoCD app controller not running on $OCP_CLUSTER_NAME"
+                KUBECONFIG=$OCP_KUBECONFIG kubectl get pods -n openshift-gitops --no-headers 2>/dev/null || true
+                return 1
+            }
+    fi
+    # Kind cluster: Redis must be ready before app controller (same race as local-cluster in S2)
+    wait_for_condition 300 "Redis on $KIND_CLUSTER_NAME" \
+        "KUBECONFIG=$KIND_KUBECONFIG kubectl get pods -n openshift-gitops -l app.kubernetes.io/name=acm-openshift-gitops-redis --field-selector=status.phase=Running --no-headers 2>/dev/null | grep -q Running" || {
+            log_error "SCENARIO 6: Redis not running on $KIND_CLUSTER_NAME"
+            return 1
+        }
+    wait_for_condition 300 "ArgoCD app controller on $KIND_CLUSTER_NAME" \
+        "KUBECONFIG=$KIND_KUBECONFIG kubectl get pods -n openshift-gitops -l app.kubernetes.io/name=acm-openshift-gitops-application-controller --field-selector=status.phase=Running --no-headers 2>/dev/null | grep -q Running" || {
+            log_error "SCENARIO 6: ArgoCD app controller not running on $KIND_CLUSTER_NAME"
+            return 1
+        }
+    # Check if the Kind app controller started with Redis unavailable and restart if needed
+    local kind_app_logs
+    kind_app_logs=$(KUBECONFIG=$KIND_KUBECONFIG kubectl logs -n openshift-gitops -l app.kubernetes.io/name=acm-openshift-gitops-application-controller --tail=100 2>/dev/null || true)
+    if echo "$kind_app_logs" | grep -q "connection refused\|Failed to save cluster info"; then
+        log_warn "Kind app controller had Redis connection issues at startup — restarting to rebuild cluster cache"
+        KUBECONFIG=$KIND_KUBECONFIG kubectl delete pod -n openshift-gitops -l app.kubernetes.io/name=acm-openshift-gitops-application-controller --grace-period=0 --force 2>/dev/null || true
+        wait_for_condition 300 "ArgoCD app controller restart on $KIND_CLUSTER_NAME" \
+            "KUBECONFIG=$KIND_KUBECONFIG kubectl get pods -n openshift-gitops -l app.kubernetes.io/name=acm-openshift-gitops-application-controller --field-selector=status.phase=Running --no-headers 2>/dev/null | grep -q Running" || {
+                log_error "SCENARIO 6: ArgoCD app controller not running after restart on $KIND_CLUSTER_NAME"
+                return 1
+            }
+        log_info "Kind app controller restarted successfully"
+    fi
+    # local-cluster: Redis must be ready before app controller
+    wait_for_condition 300 "Redis on $LOCAL_CLUSTER_NAME" \
+        "kubectl get pods -n local-cluster -l app.kubernetes.io/name=acm-openshift-gitops-redis --field-selector=status.phase=Running --no-headers 2>/dev/null | grep -q Running" || {
+            log_error "SCENARIO 6: Redis not running on $LOCAL_CLUSTER_NAME"
+            return 1
+        }
+    wait_for_condition 300 "ArgoCD app controller on $LOCAL_CLUSTER_NAME" \
+        "kubectl get pods -n local-cluster -l app.kubernetes.io/name=acm-openshift-gitops-application-controller --field-selector=status.phase=Running --no-headers 2>/dev/null | grep -q Running" || {
+            log_error "SCENARIO 6: ArgoCD app controller not running on $LOCAL_CLUSTER_NAME"
+            kubectl get pods -n local-cluster --no-headers 2>/dev/null || true
+            return 1
+        }
+    # Check if the local-cluster app controller started with Redis unavailable and restart if needed
+    local local_app_logs
+    local_app_logs=$(kubectl logs -n local-cluster -l app.kubernetes.io/name=acm-openshift-gitops-application-controller --tail=100 2>/dev/null || true)
+    if echo "$local_app_logs" | grep -q "connection refused\|Failed to save cluster info"; then
+        log_warn "local-cluster app controller had Redis connection issues at startup — restarting to rebuild cluster cache"
+        kubectl delete pod -n local-cluster -l app.kubernetes.io/name=acm-openshift-gitops-application-controller --grace-period=0 --force 2>/dev/null || true
+        wait_for_condition 300 "ArgoCD app controller restart on $LOCAL_CLUSTER_NAME" \
+            "kubectl get pods -n local-cluster -l app.kubernetes.io/name=acm-openshift-gitops-application-controller --field-selector=status.phase=Running --no-headers 2>/dev/null | grep -q Running" || {
+                log_error "SCENARIO 6: ArgoCD app controller not running after restart on $LOCAL_CLUSTER_NAME"
+                return 1
+            }
+        log_info "local-cluster app controller restarted successfully"
+    fi
+
+    # Verify no duplicate ArgoCD
+    verify_no_duplicate_argocd "$HUB_KUBECONFIG" "$LOCAL_CLUSTER_NAME" || return 1
+    if [ "$HAS_OCP" = true ]; then
+        verify_no_duplicate_argocd "$OCP_KUBECONFIG" "$OCP_CLUSTER_NAME" || return 1
+    fi
+    verify_no_duplicate_argocd "$KIND_KUBECONFIG" "$KIND_CLUSTER_NAME" || return 1
+
+    # Verify Red Hat images
+    if [ "$HAS_OCP" = true ]; then
+        verify_redhat_images "$OCP_KUBECONFIG" "$OCP_CLUSTER_NAME" "openshift-gitops" || {
+            log_error "SCENARIO 6: Non-Red Hat images on $OCP_CLUSTER_NAME"
+            return 1
+        }
+    fi
+    verify_redhat_images "$KIND_KUBECONFIG" "$KIND_CLUSTER_NAME" "openshift-gitops" || {
+        log_error "SCENARIO 6: Non-Red Hat images on $KIND_CLUSTER_NAME"
+        return 1
+    }
+    verify_redhat_images "$HUB_KUBECONFIG" "$LOCAL_CLUSTER_NAME" "local-cluster" || {
+        log_error "SCENARIO 6: Non-Red Hat images on $LOCAL_CLUSTER_NAME"
+        return 1
+    }
+
+    # --- Validate guestbook on managed clusters ---
+    # In autonomous mode, the Policy creates the Application on the managed cluster.
+    # The local ArgoCD app controller reconciles it.
+
+    if [ "$HAS_OCP" = true ]; then
+        wait_for_condition 300 "Guestbook on $OCP_CLUSTER_NAME via autonomous agent" \
+            "KUBECONFIG=$OCP_KUBECONFIG kubectl get deployment guestbook-ui -n guestbook -o name" || {
+                log_error "SCENARIO 6: Guestbook not deployed on $OCP_CLUSTER_NAME"
+                KUBECONFIG=$OCP_KUBECONFIG kubectl get applications.argoproj.io -n openshift-gitops -o wide 2>/dev/null || true
+                KUBECONFIG=$OCP_KUBECONFIG kubectl logs -n openshift-gitops -l app.kubernetes.io/part-of=argocd-agent --tail=20 2>/dev/null || true
+                return 1
+            }
+        log_info "NOTE: On OCP, guestbook-ui pods crash (port 80 + restricted SCC) - expected"
+    fi
+
+    # Kind: guestbook via Policy + autonomous agent
+    wait_for_condition 600 "Guestbook on $KIND_CLUSTER_NAME via autonomous agent" \
+        "KUBECONFIG=$KIND_KUBECONFIG kubectl get deployment guestbook-ui -n guestbook -o name" || {
+            log_error "SCENARIO 6: Guestbook not deployed on $KIND_CLUSTER_NAME"
+            log_error "--- Diagnostics for $KIND_CLUSTER_NAME autonomous agent failure ---"
+            export KUBECONFIG=$HUB_KUBECONFIG
+            log_error "Policy status:"
+            kubectl get policy all-autonomous-gitops-argocd-policy -n openshift-gitops -o jsonpath='{.status.compliant}' 2>/dev/null; echo
+            log_error "ArgoCD CR on spoke:"
+            KUBECONFIG=$KIND_KUBECONFIG kubectl get argocd -n openshift-gitops -o yaml 2>/dev/null | head -60 || true
+            log_error "Applications on spoke:"
+            KUBECONFIG=$KIND_KUBECONFIG kubectl get applications.argoproj.io -n openshift-gitops -o wide 2>/dev/null || true
+            log_error "Agent logs on $KIND_CLUSTER_NAME (last 30 lines):"
+            KUBECONFIG=$KIND_KUBECONFIG kubectl logs -n openshift-gitops -l app.kubernetes.io/part-of=argocd-agent --tail=30 2>/dev/null || true
+            log_error "App controller logs on $KIND_CLUSTER_NAME (last 30 lines):"
+            KUBECONFIG=$KIND_KUBECONFIG kubectl logs -n openshift-gitops -l app.kubernetes.io/name=acm-openshift-gitops-application-controller --tail=30 2>/dev/null || true
+            log_error "--- End diagnostics ---"
+            return 1
+        }
+    wait_for_condition 120 "Guestbook pods ready on $KIND_CLUSTER_NAME" \
+        "KUBECONFIG=$KIND_KUBECONFIG kubectl get deployment guestbook-ui -n guestbook -o jsonpath='{.status.availableReplicas}' | grep -q '[1-9]'" || {
+            log_warn "Guestbook pods not ready on Kind (continuing)"
+        }
+
+    # local-cluster: verify autonomous agent infrastructure (but skip guestbook app verification)
+    # In autonomous mode on local-cluster (which IS the hub), the agent transforms Application
+    # specs (project → namespace-prefixed, destination → cluster name) which conflicts with
+    # the Policy that enforces the original spec. This is a known limitation: autonomous agents
+    # are designed for remote managed clusters. We verify infrastructure only.
+    export KUBECONFIG=$HUB_KUBECONFIG
+
+    # Wait for ArgoCD to be running in local-cluster namespace
+    wait_for_condition 120 "ArgoCD in local-cluster namespace" \
+        "kubectl get argocd acm-openshift-gitops -n local-cluster -o name" || return 1
+
+    # Verify no duplicate ArgoCD
+    verify_no_duplicate_argocd "$HUB_KUBECONFIG" "$LOCAL_CLUSTER_NAME" || return 1
+
+    # Verify agent client cert
+    wait_for_condition 180 "ArgoCD agent client cert in local-cluster" \
+        "kubectl get secret argocd-agent-client-tls -n local-cluster -o name" || {
+            log_warn "Client cert not yet provisioned for local-cluster (continuing)"
+        }
+
+    log_info "local-cluster autonomous mode: infrastructure verified (guestbook app sync skipped — known limitation on hub)"
+
+    # Verify Application sync status on managed clusters
+    export KUBECONFIG=$HUB_KUBECONFIG
+    if [ "$HAS_OCP" = true ]; then
+        wait_for_condition 180 "OCP guestbook app Synced on $OCP_CLUSTER_NAME" \
+            "KUBECONFIG=$OCP_KUBECONFIG kubectl get applications.argoproj.io guestbook -n openshift-gitops -o jsonpath='{.status.sync.status}' 2>/dev/null | grep -q 'Synced'" || {
+                log_warn "OCP guestbook app not yet Synced"
+            }
+    fi
+    wait_for_condition 180 "Kind guestbook app Synced on $KIND_CLUSTER_NAME" \
+        "KUBECONFIG=$KIND_KUBECONFIG kubectl get applications.argoproj.io guestbook -n openshift-gitops -o jsonpath='{.status.sync.status}' 2>/dev/null | grep -q 'Synced'" || {
+            log_warn "Kind guestbook app not yet Synced"
+        }
+
+    # Verify the ArgoCD CR on the managed cluster has mode: autonomous
+    if [ "$HAS_OCP" = true ]; then
+        local ocp_mode
+        ocp_mode=$(KUBECONFIG=$OCP_KUBECONFIG kubectl get argocd acm-openshift-gitops -n openshift-gitops \
+            -o jsonpath='{.spec.argoCDAgent.agent.client.mode}' 2>/dev/null)
+        if [ "$ocp_mode" != "autonomous" ]; then
+            log_error "SCENARIO 6: ArgoCD agent mode on $OCP_CLUSTER_NAME is '$ocp_mode' (expected: autonomous)"
+            return 1
+        fi
+        log_info "  ArgoCD agent mode on $OCP_CLUSTER_NAME: autonomous: OK"
+    fi
+    local kind_mode
+    kind_mode=$(KUBECONFIG=$KIND_KUBECONFIG kubectl get argocd acm-openshift-gitops -n openshift-gitops \
+        -o jsonpath='{.spec.argoCDAgent.agent.client.mode}' 2>/dev/null)
+    if [ "$kind_mode" != "autonomous" ]; then
+        log_error "SCENARIO 6: ArgoCD agent mode on $KIND_CLUSTER_NAME is '$kind_mode' (expected: autonomous)"
+        return 1
+    fi
+    log_info "  ArgoCD agent mode on $KIND_CLUSTER_NAME: autonomous: OK"
+
+    # Report sync statuses
+    local ocp_sync="SKIPPED"
+    if [ "$HAS_OCP" = true ]; then
+        ocp_sync=$(KUBECONFIG=$OCP_KUBECONFIG kubectl get applications.argoproj.io guestbook -n openshift-gitops -o jsonpath='{.status.sync.status}' 2>/dev/null)
+    fi
+    local kind_sync=$(KUBECONFIG=$KIND_KUBECONFIG kubectl get applications.argoproj.io guestbook -n openshift-gitops -o jsonpath='{.status.sync.status}' 2>/dev/null)
+
+    # Environment health
+    if [ "$HAS_OCP" = true ]; then
+        verify_environment_health "$OCP_KUBECONFIG" "$OCP_CLUSTER_NAME" "6" "false" || return 1
+    fi
+    verify_environment_health "$KIND_KUBECONFIG" "$KIND_CLUSTER_NAME" "6" "false" || return 1
+    verify_environment_health "$HUB_KUBECONFIG" "$LOCAL_CLUSTER_NAME" "6" "true" || return 1
+
+    log_info "=============================================="
+    log_info "SCENARIO 6: PASSED"
+    log_info "  - Autonomous agent mode with Policy-based app delivery: OK"
+    if [ "$HAS_OCP" = true ]; then
+        log_info "  - OLM auto-detected on OCP: OK"
+        log_info "  - Guestbook on $OCP_CLUSTER_NAME (Sync=$ocp_sync): OK"
+    else
+        log_info "  - OCP: SKIPPED (not available)"
+    fi
+    log_info "  - Agents connected: OK"
+    log_info "  - ARGOCD_AGENT_MODE=autonomous propagated: OK"
+    log_info "  - ArgoCD CR mode=autonomous verified: OK"
+    log_info "  - No duplicate ArgoCD: OK"
+    log_info "  - Red Hat images: OK"
+    log_info "  - Guestbook on $KIND_CLUSTER_NAME (Sync=$kind_sync): OK"
+    log_info "  - local-cluster: infrastructure verified (app sync skipped — autonomous on hub limitation)"
+    log_info "=============================================="
+    return 0
+}
+
+#######################################
 # Main
 #######################################
 
@@ -2789,6 +3149,11 @@ case "${1:-all}" in
         test_scenario_5
         cleanup_scenario "all-agent-gitops" "all-agent-placement" "${CLEANUP_CLUSTERS[@]}"
         ;;
+    6)
+        cleanup_scenario "all-autonomous-gitops" "all-autonomous-placement" "${CLEANUP_CLUSTERS[@]}"
+        test_scenario_6
+        cleanup_scenario "all-autonomous-gitops" "all-autonomous-placement" "${CLEANUP_CLUSTERS[@]}"
+        ;;
     all)
         cleanup_all
         ensure_hub_controller_image
@@ -2802,10 +3167,12 @@ case "${1:-all}" in
         scenario3_result="SKIPPED"
         scenario4_result="SKIPPED"
         scenario5_result="SKIPPED"
+        scenario6_result="SKIPPED"
         cleanup1_result="SKIPPED"
         cleanup2_result="SKIPPED"
         cleanup3_result="SKIPPED"
         cleanup4_result="SKIPPED"
+        cleanup6_result="SKIPPED"
 
         # --- Scenario 1: No Agent ---
         if test_scenario_1; then scenario1_result="PASSED"; else scenario1_result="FAILED"; fi
@@ -2834,6 +3201,11 @@ case "${1:-all}" in
         # --- Scenario 4: OLM Override on Kind ---
         if test_scenario_4; then scenario4_result="PASSED"; else scenario4_result="FAILED"; fi
         if cleanup_scenario "kind-olm-override-gitops" "kind-olm-override-placement" "$KIND_CLUSTER_NAME"; then cleanup4_result="PASSED"; else cleanup4_result="FAILED"; fi
+        sleep 15
+
+        # --- Scenario 6: Autonomous Agent Mode ---
+        if test_scenario_6; then scenario6_result="PASSED"; else scenario6_result="FAILED"; fi
+        if cleanup_scenario "all-autonomous-gitops" "all-autonomous-placement" "${CLEANUP_CLUSTERS[@]}"; then cleanup6_result="PASSED"; else cleanup6_result="FAILED"; fi
 
         log_info "=============================================="
         log_info "=== ALL SCENARIOS COMPLETE ==="
@@ -2847,12 +3219,15 @@ case "${1:-all}" in
         log_info "  Cleanup 3:                                  $cleanup3_result"
         log_info "  Scenario 4 (OLM Override on Kind):         $scenario4_result"
         log_info "  Cleanup 4:                                  $cleanup4_result"
+        log_info "  Scenario 6 (Autonomous Agent):             $scenario6_result"
+        log_info "  Cleanup 6:                                  $cleanup6_result"
         [ "$HAS_OCP" != true ] && log_info "  NOTE: OCP not available — OCP parts skipped"
         log_info "=============================================="
 
         if [[ "$scenario1_result" == "FAILED" || "$scenario2_result" == "FAILED" || "$scenario3_result" == "FAILED" || \
-              "$scenario4_result" == "FAILED" || "$scenario5_result" == "FAILED" || \
-              "$cleanup1_result" == "FAILED" || "$cleanup2_result" == "FAILED" || "$cleanup3_result" == "FAILED" || "$cleanup4_result" == "FAILED" ]]; then
+              "$scenario4_result" == "FAILED" || "$scenario5_result" == "FAILED" || "$scenario6_result" == "FAILED" || \
+              "$cleanup1_result" == "FAILED" || "$cleanup2_result" == "FAILED" || "$cleanup3_result" == "FAILED" || \
+              "$cleanup4_result" == "FAILED" || "$cleanup6_result" == "FAILED" ]]; then
             exit 1
         fi
         ;;
@@ -2860,13 +3235,14 @@ case "${1:-all}" in
         cleanup_all
         ;;
     *)
-        echo "Usage: $0 [1|2|3|4|5|all|cleanup]"
+        echo "Usage: $0 [1|2|3|4|5|6|all|cleanup]"
         echo ""
         echo "  1       - Scenario 1: No Agent (OCP + Kind + local-cluster)"
         echo "  2       - Scenario 2: Agent Mode (OCP + Kind + local-cluster)"
         echo "  3       - Scenario 3: Custom OLM (OCP only)"
         echo "  4       - Scenario 4: OLM Override on Kind (Kind only)"
         echo "  5       - Scenario 5: Agent Version Drift Heal (deploys S2 first)"
+        echo "  6       - Scenario 6: Autonomous Agent Mode (OCP + Kind + local-cluster)"
         echo "  all     - Run all scenarios sequentially with cleanup"
         echo "  cleanup - Force cleanup everything"
         echo ""

--- a/pkg/controller/gitopscluster/argocd_policy.go
+++ b/pkg/controller/gitopscluster/argocd_policy.go
@@ -170,7 +170,8 @@ subjects:
 // 1. Delete Policy CR first (stops enforcement, allows cleanup job to delete ArgoCD CR)
 // 2. Delete ManagedClusterAddOn -> cleanup job runs and deletes ArgoCD CR and other resources
 // 3. Delete GitOpsCluster CR
-// When ArgoCD agent is enabled, AppProject is NOT included because argocd-agent propagates it from the hub.
+// When ArgoCD agent is enabled in managed mode, AppProject is NOT included because argocd-agent propagates it from the hub.
+// When ArgoCD agent is enabled in autonomous mode, AppProject IS included because Applications are reconciled locally.
 func generateArgoCDPolicyYaml(gitOpsCluster gitopsclusterV1beta1.GitOpsCluster) string {
 	argoCDSpec := generateArgoCDSpec(gitOpsCluster)
 
@@ -226,9 +227,22 @@ spec:
 		namespaceTemplate,
 		indentYaml(argoCDSpec, 18))
 
-	// Only include AppProject when ArgoCD agent is NOT enabled.
-	// When argocd-agent is enabled, AppProject is propagated from the hub by the agent.
-	if !argoCDAgentEnabled {
+	// Determine the agent mode
+	agentMode := ""
+	if argoCDAgentEnabled && gitOpsCluster.Spec.GitOpsAddon != nil && gitOpsCluster.Spec.GitOpsAddon.ArgoCDAgent != nil {
+		agentMode = gitOpsCluster.Spec.GitOpsAddon.ArgoCDAgent.Mode
+	}
+
+	// Include AppProject when:
+	// - ArgoCD agent is NOT enabled (non-agent mode needs it directly), OR
+	// - ArgoCD agent IS enabled AND mode is "autonomous" (autonomous agents reconcile
+	//   Applications locally and need the AppProject present before the principal
+	//   propagates it; including it in the Policy guarantees correct ordering)
+	// Exclude AppProject when agent is enabled in managed mode (principal propagates it).
+	if !argoCDAgentEnabled || agentMode == "autonomous" {
+		if agentMode == "autonomous" {
+			klog.Infof("ArgoCD agent autonomous mode: including AppProject in policy (needed for local reconciliation)")
+		}
 		yamlString += fmt.Sprintf(`
             - complianceType: musthave
               objectDefinition:
@@ -248,7 +262,7 @@ spec:
                     - '*'
 `, namespaceTemplate)
 	} else {
-		klog.Infof("ArgoCD agent is enabled, excluding AppProject from policy (will be propagated by agent)")
+		klog.Infof("ArgoCD agent is enabled (managed mode), excluding AppProject from policy (will be propagated by agent)")
 		yamlString += "\n"
 	}
 

--- a/pkg/controller/gitopscluster/argocd_policy_test.go
+++ b/pkg/controller/gitopscluster/argocd_policy_test.go
@@ -164,6 +164,45 @@ func TestGenerateArgoCDPolicyYaml_ExcludesAppProjectWhenAgentEnabled(t *testing.
 	assert.Contains(t, yamlString, "principalServerAddress")
 }
 
+func TestGenerateArgoCDPolicyYaml_IncludesAppProjectWhenAgentAutonomous(t *testing.T) {
+	enabled := true
+	agentEnabled := true
+	gitOpsCluster := gitopsclusterV1beta1.GitOpsCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gitops",
+			Namespace: "openshift-gitops",
+			UID:       "test-uid",
+		},
+		Spec: gitopsclusterV1beta1.GitOpsClusterSpec{
+			PlacementRef: &v1.ObjectReference{
+				Name: "test-placement",
+				Kind: "Placement",
+			},
+			GitOpsAddon: &gitopsclusterV1beta1.GitOpsAddonSpec{
+				Enabled: &enabled,
+				ArgoCDAgent: &gitopsclusterV1beta1.ArgoCDAgentSpec{
+					Enabled:       &agentEnabled,
+					ServerAddress: "principal.example.com",
+					ServerPort:    "443",
+					Mode:          "autonomous",
+				},
+			},
+		},
+	}
+
+	yamlString := generateArgoCDPolicyYaml(gitOpsCluster)
+
+	// AppProject SHOULD be included when agent is in autonomous mode
+	// (autonomous agents reconcile Applications locally and need AppProject)
+	assert.Contains(t, yamlString, "kind: AppProject")
+	assert.Contains(t, yamlString, "name: default")
+
+	// Should still contain the ArgoCD CR with agent config
+	assert.Contains(t, yamlString, "kind: ArgoCD")
+	assert.Contains(t, yamlString, "mode: \"autonomous\"")
+	assert.Contains(t, yamlString, "principalServerAddress")
+}
+
 func TestGenerateArgoCDSpec_BasicConfig(t *testing.T) {
 	enabled := true
 	gitOpsCluster := gitopsclusterV1beta1.GitOpsCluster{

--- a/test/e2e/gitopsaddon/gitopsaddon_embedded_autonomous_test.go
+++ b/test/e2e/gitopsaddon/gitopsaddon_embedded_autonomous_test.go
@@ -1,0 +1,134 @@
+//go:build e2e
+
+package gitopsaddon_e2e
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Mirrors test-scenarios.sh Scenario 6: Kind cluster + local-cluster, autonomous agent mode
+var _ = Describe("GitOps Addon - Embedded Operator + Autonomous Agent (Kind)", Label("embedded-autonomous"), Ordered, func() {
+	SetDefaultEventuallyTimeout(5 * time.Minute)
+	SetDefaultEventuallyPollingInterval(5 * time.Second)
+
+	var opts gitOpsClusterOpts
+
+	BeforeAll(func() {
+		opts = gitOpsClusterOpts{
+			name:          gitopsClusterName,
+			namespace:     argoCDNamespace,
+			placementName: placementName,
+			agentEnabled:  true,
+			agentMode:     "autonomous",
+		}
+		createBaseResources()
+		createGitOpsCluster(opts)
+	})
+
+	AfterAll(func() {
+		safeCleanup(opts)
+	})
+
+	Context("Spoke + Autonomous Agent Deployment", func() {
+		It("should create ManagedClusterAddOn and deploy addon on spoke", func() {
+			verifyAddonDeployed(8 * time.Minute)
+		})
+
+		It("should deploy embedded operator on spoke", func() {
+			verifyEmbeddedOperator(5 * time.Minute)
+		})
+
+		It("should deploy ArgoCD CR and application-controller on spoke", func() {
+			verifyArgoCDOnSpoke(8 * time.Minute)
+		})
+
+		It("should deploy ArgoCD agent pod on spoke", func() {
+			verifyAgentPodRunning(10 * time.Minute)
+		})
+
+		It("should auto-discover principal server address from hub ArgoCD", func() {
+			verifyPrincipalServerAddress(3 * time.Minute)
+		})
+
+		It("should create cluster secret with agent URL on hub", func() {
+			verifyClusterSecret(3 * time.Minute)
+		})
+
+		It("should have all GitOpsCluster conditions True", func() {
+			verifyGitOpsClusterConditions([]string{
+				"Ready",
+				"PlacementResolved",
+				"ArgoServerVerified",
+				"ClustersRegistered",
+				"AddOnDeploymentConfigsReady",
+				"ManagedClusterAddOnsReady",
+				"ArgoCDPolicyReady",
+			}, 3*time.Minute)
+		})
+
+		It("should propagate ARGOCD_AGENT_ENABLED=true to AddOnDeploymentConfig", func() {
+			verifyAddOnDeploymentConfigEnvVar(spokeName, "ARGOCD_AGENT_ENABLED", "true", 3*time.Minute)
+		})
+
+		It("should propagate ARGOCD_AGENT_MODE=autonomous to AddOnDeploymentConfig", func() {
+			verifyAddOnDeploymentConfigEnvVar(spokeName, "ARGOCD_AGENT_MODE", "autonomous", 3*time.Minute)
+		})
+
+		It("should propagate OLM_SUBSCRIPTION_ENABLED=false to AddOnDeploymentConfig", func() {
+			verifyAddOnDeploymentConfigEnvVar(spokeName, "OLM_SUBSCRIPTION_ENABLED", "false", 3*time.Minute)
+		})
+	})
+
+	Context("Autonomous Agent Application Sync via Policy", func() {
+		It("should deploy guestbook via Policy on spoke and verify sync", func() {
+			deployGuestbookAutonomousMode(15 * time.Minute)
+		})
+	})
+
+	Context("Spoke Environment Health", func() {
+		It("should have no cross-namespace application controller conflicts", func() {
+			verifyEnvironmentHealth(spokeContext)
+		})
+	})
+
+	Context("Local-Cluster Verification", func() {
+		It("should create ManagedClusterAddOn for local-cluster", func() {
+			verifyLocalClusterAddon(5 * time.Minute)
+		})
+
+		It("should verify autonomous agent infrastructure on local-cluster (hub)", func() {
+			verifyLocalClusterAutonomousInfrastructure(8 * time.Minute)
+		})
+
+		It("should have no cross-namespace conflicts on local-cluster", func() {
+			verifyLocalClusterEnvironmentHealth()
+		})
+	})
+
+	Context("Cleanup", func() {
+		It("should clean up guestbook resources", func() {
+			cleanupGuestbookAutonomous()
+		})
+
+		It("should delete all scenario resources in proper order", func() {
+			scenarioCleanup(opts)
+		})
+	})
+
+	Context("Cleanup Verification", func() {
+		It("should have removed GitOpsCluster, MCA (spoke), and MCA (local-cluster) from hub", func() {
+			verifyHubCleanup(opts)
+		})
+
+		It("should have removed ArgoCD CR and operator from spoke", func() {
+			verifySpokeCleanup()
+		})
+
+		It("should have removed ArgoCD CR from local-cluster namespace on hub", func() {
+			verifyLocalClusterCleanup()
+		})
+	})
+})

--- a/test/e2e/gitopsaddon/helpers_test.go
+++ b/test/e2e/gitopsaddon/helpers_test.go
@@ -126,6 +126,7 @@ type gitOpsClusterOpts struct {
 	namespace     string
 	placementName string
 	agentEnabled  bool
+	agentMode     string // "managed" or "autonomous" (empty defaults to managed)
 	olmEnabled    bool
 	olmSource     string
 	olmSourceNS   string
@@ -154,6 +155,11 @@ spec:
     enabled: true
     argoCDAgent:
       enabled: %t`, opts.agentEnabled)
+
+	if opts.agentMode != "" {
+		spec += fmt.Sprintf(`
+      mode: %s`, opts.agentMode)
+	}
 
 	if opts.olmEnabled {
 		spec += `
@@ -1193,6 +1199,168 @@ func verifyAgentVersionDriftHeal(gitopsClusterName, ns string, timeout time.Dura
 	_, err = kubectlCtx(hubContext, "patch", "gitopscluster", gitopsClusterName, "-n", ns,
 		"--type=merge", "-p", `{"spec":{"gitopsAddon":{"overrideExistingConfigs":false}}}`)
 	Expect(err).NotTo(HaveOccurred(), "failed to restore gitopscluster overrideExistingConfigs=false after drift heal test")
+}
+
+// ---- Autonomous mode helpers ----
+
+func patchPolicyWithRBACAndApp(policyName, ns string) {
+	By(fmt.Sprintf("waiting for Policy %s to be created by controller", policyName))
+	waitForResourceExists(hubContext, "policy.policy.open-cluster-management.io",
+		policyName, ns, 2*time.Minute)
+
+	By("patching Policy with RBAC (cluster-admin) and guestbook Application")
+	patchJSON := fmt.Sprintf(`[{
+  "op": "add",
+  "path": "/spec/policy-templates/-",
+  "value": {
+    "objectDefinition": {
+      "apiVersion": "policy.open-cluster-management.io/v1",
+      "kind": "ConfigurationPolicy",
+      "metadata": { "name": "%s-rbac" },
+      "spec": {
+        "remediationAction": "enforce",
+        "severity": "medium",
+        "object-templates": [
+          {
+            "complianceType": "musthave",
+            "objectDefinition": {
+              "apiVersion": "rbac.authorization.k8s.io/v1",
+              "kind": "ClusterRoleBinding",
+              "metadata": { "name": "acm-openshift-gitops-cluster-admin" },
+              "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "cluster-admin"
+              },
+              "subjects": [{
+                "kind": "ServiceAccount",
+                "name": "acm-openshift-gitops-argocd-application-controller",
+                "namespace": "%s"
+              }]
+            }
+          },
+          {
+            "complianceType": "musthave",
+            "objectDefinition": {
+              "apiVersion": "v1",
+              "kind": "Namespace",
+              "metadata": { "name": "guestbook" }
+            }
+          },
+          {
+            "complianceType": "musthave",
+            "objectDefinition": {
+              "apiVersion": "argoproj.io/v1alpha1",
+              "kind": "Application",
+              "metadata": {
+                "name": "guestbook",
+                "namespace": "%s"
+              },
+              "spec": {
+                "project": "default",
+                "source": {
+                  "repoURL": "https://github.com/argoproj/argocd-example-apps",
+                  "targetRevision": "HEAD",
+                  "path": "guestbook"
+                },
+                "destination": {
+                  "server": "https://kubernetes.default.svc",
+                  "namespace": "guestbook"
+                },
+                "syncPolicy": {
+                  "automated": { "prune": true, "selfHeal": true }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}]`, policyName, ns, ns)
+
+	_, err := kubectlCtx(hubContext, "patch", "policy.policy.open-cluster-management.io",
+		policyName, "-n", ns, "--type=json", fmt.Sprintf("-p=%s", patchJSON))
+	Expect(err).NotTo(HaveOccurred(), "failed to patch Policy with RBAC and guestbook Application")
+}
+
+func deployGuestbookAutonomousMode(timeout time.Duration) {
+	policyName := gitopsClusterName + "-argocd-policy"
+
+	ensureHubPrincipalRunning()
+
+	patchPolicyWithRBACAndApp(policyName, argoCDNamespace)
+
+	By("waiting for Policy to be Compliant (all templates enforced on spoke)")
+	Eventually(func(g Gomega) string {
+		out, err := kubectlCtx(hubContext, "get", "policy.policy.open-cluster-management.io",
+			policyName, "-n", argoCDNamespace,
+			"-o", "jsonpath={.status.compliant}")
+		g.Expect(err).NotTo(HaveOccurred())
+		return out
+	}, 7*time.Minute, 10*time.Second).Should(Equal("Compliant"))
+
+	By("verifying guestbook-ui deployment exists on spoke via autonomous agent")
+	Eventually(func(g Gomega) int {
+		out, err := kubectlCtx(spokeContext, "get", "deployment", "guestbook-ui",
+			"-n", "guestbook",
+			"-o", "jsonpath={.status.availableReplicas}")
+		if err != nil {
+			appInfo, _ := kubectlCtx(spokeContext, "get", "applications.argoproj.io", "guestbook",
+				"-n", argoCDNamespace,
+				"-o", "jsonpath=sync={.status.sync.status} health={.status.health.status}")
+			fmt.Fprintf(GinkgoWriter, "  [diag] guestbook-ui not found on spoke; app: %s\n", appInfo)
+		}
+		g.Expect(err).NotTo(HaveOccurred())
+		if out == "" {
+			return 0
+		}
+		replicas, convErr := strconv.Atoi(strings.TrimSpace(out))
+		g.Expect(convErr).NotTo(HaveOccurred())
+		return replicas
+	}, timeout, 10*time.Second).Should(BeNumerically(">", 0))
+
+	By("checking Application sync status on spoke (informational)")
+	spokeSync, _ := kubectlCtx(spokeContext, "get", "applications.argoproj.io", "guestbook",
+		"-n", argoCDNamespace,
+		"-o", "jsonpath={.status.sync.status}")
+	fmt.Fprintf(GinkgoWriter, "  [info] spoke Application guestbook sync status: %s\n", spokeSync)
+}
+
+func verifyLocalClusterAutonomousInfrastructure(timeout time.Duration) {
+	By("verifying ArgoCD CR in local-cluster namespace")
+	waitForResourceExists(hubContext, "argocd", "acm-openshift-gitops", localClusterName, timeout)
+
+	verifyNoDuplicateArgoCDOnHub()
+
+	By("verifying agent client cert in local-cluster namespace")
+	Eventually(func() error {
+		_, err := kubectlCtx(hubContext, "get", "secret", "argocd-agent-client-tls",
+			"-n", localClusterName)
+		return err
+	}, 3*time.Minute, 10*time.Second).Should(Succeed())
+
+	fmt.Fprintf(GinkgoWriter,
+		"  [info] local-cluster autonomous infrastructure verified "+
+			"(app sync skipped — known limitation on hub)\n")
+}
+
+func cleanupGuestbookAutonomous() {
+	By("cleaning up guestbook app on spoke (deployed by Policy)")
+	kubectlCtx(spokeContext, "delete", "applications.argoproj.io", "guestbook",
+		"-n", argoCDNamespace, "--ignore-not-found")
+	kubectlCtx(spokeContext, "delete", "namespace", "guestbook", "--ignore-not-found", "--wait=false")
+	kubectlCtx(spokeContext, "delete", "clusterrolebinding",
+		"acm-openshift-gitops-cluster-admin", "--ignore-not-found")
+
+	By("cleaning up guestbook resources on local-cluster (hub)")
+	kubectlCtx(hubContext, "delete", "applications.argoproj.io", "guestbook",
+		"-n", localClusterName, "--ignore-not-found")
+	kubectlCtx(hubContext, "delete", "appproject", "default",
+		"-n", localClusterName, "--ignore-not-found")
+	kubectlCtx(hubContext, "delete", "namespace", "guestbook", "--ignore-not-found", "--wait=false")
+	kubectlCtx(hubContext, "delete", "clusterrolebinding",
+		"acm-openshift-gitops-cluster-admin", "--ignore-not-found")
 }
 
 // ---- OLM Override helpers ----


### PR DESCRIPTION
feat: Add autonomous agent mode support  with AppProject fix, e2e tests, and test scenarios

Include default AppProject in generated Policy for autonomous mode so Applications can reconcile locally before principal propagation. Add Scenario 6 to test-scenarios.sh covering OCP, Kind, and local-cluster. Add embedded-autonomous e2e test suite and CI workflow entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Autonomous Agent Mode for GitOps addon, enabling autonomous synchronization of applications and policies on managed clusters.
  * Added new E2E test scenario (Scenario 6) for autonomous agent mode validation.

* **Improvements**
  * Enhanced logging configuration with new `logFormat` property for Argo CD Notifications and ApplicationSet controllers.

* **Documentation**
  * Expanded documentation covering autonomous agent mode behavior, AppProject propagation, setup instructions, and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->