### PR TITLE
Enable basic pull model (propagation controller) for local-cluster

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,6 +84,8 @@ jobs:
             make_target: test-e2e-gitopsaddon-olm-override
           - scenario: embedded-autonomous
             make_target: test-e2e-gitopsaddon-embedded-autonomous
+          - scenario: embedded-pull
+            make_target: test-e2e-gitopsaddon-embedded-pull
     steps:
       - name: Free up disk space
         run: |

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,10 @@ test-e2e-gitopsaddon-olm-override: manifests
 test-e2e-gitopsaddon-embedded-autonomous: manifests
 	$(call RUN_GITOPSADDON_E2E,embedded-autonomous)
 
+.PHONY: test-e2e-gitopsaddon-embedded-pull
+test-e2e-gitopsaddon-embedded-pull: manifests
+	$(call RUN_GITOPSADDON_E2E,embedded-pull)
+
 # --- Scenarios (Local) ---
 
 .PHONY: test-local-e2e-gitopsaddon-embedded
@@ -247,6 +251,11 @@ test-local-e2e-gitopsaddon-embedded-autonomous:
 	$(SETUP_KIND_CLUSTERS)
 	$(MAKE) test-e2e-gitopsaddon-embedded-autonomous
 
+.PHONY: test-local-e2e-gitopsaddon-embedded-pull
+test-local-e2e-gitopsaddon-embedded-pull:
+	$(SETUP_KIND_CLUSTERS)
+	$(MAKE) test-e2e-gitopsaddon-embedded-pull
+
 # --- Aggregate targets ---
 
 .PHONY: test-e2e-gitopsaddon-all
@@ -255,6 +264,7 @@ test-e2e-gitopsaddon-all:
 	$(MAKE) test-e2e-gitopsaddon-embedded-agent
 	$(MAKE) test-e2e-gitopsaddon-olm-override
 	$(MAKE) test-e2e-gitopsaddon-embedded-autonomous
+	$(MAKE) test-e2e-gitopsaddon-embedded-pull
 
 .PHONY: clean-e2e
 clean-e2e:

--- a/propagation-controller/application/application_controller.go
+++ b/propagation-controller/application/application_controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -116,32 +115,6 @@ func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrent
 		For(applicationGVK).
 		WithEventFilter(ApplicationPredicateFunctions).
 		Complete(r)
-}
-
-func (r *ApplicationReconciler) isLocalCluster(clusterName string) bool {
-	managedCluster := &clusterv1.ManagedCluster{}
-	managedClusterKey := types.NamespacedName{
-		Name: clusterName,
-	}
-	err := r.Get(context.TODO(), managedClusterKey, managedCluster)
-
-	if err != nil {
-		klog.Errorf("Failed to find managed cluster: %v, error: %v ", clusterName, err)
-		return false
-	}
-
-	labels := managedCluster.GetLabels()
-
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-
-	if strings.EqualFold(labels["local-cluster"], "true") {
-		klog.Infof("This is local-cluster: %v", clusterName)
-		return true
-	}
-
-	return false
 }
 
 // discoverAndFetchAppProject discovers the ArgoCD instance namespace and fetches the AppProject by:
@@ -423,12 +396,6 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	managedClusterName := application.GetAnnotations()[AnnotationKeyOCMManagedCluster]
-
-	if r.isLocalCluster(managedClusterName) {
-		log.Info("skipping Application with the local-cluster as Managed Cluster")
-
-		return ctrl.Result{}, nil
-	}
 
 	mwName := generateManifestWorkName(application.GetName(), application.GetUID())
 

--- a/propagation-controller/application/application_controller_test.go
+++ b/propagation-controller/application/application_controller_test.go
@@ -206,7 +206,7 @@ var _ = Describe("Application Pull controller", func() {
 	})
 
 	Context("When Application with OCM pull label is created for local-cluster", func() {
-		It("Should not create ManifestWork", func() {
+		It("Should create ManifestWork for local-cluster", func() {
 			By("Creating the OCM ManagedCluster")
 			managedCluster := clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -245,14 +245,11 @@ var _ = Describe("Application Pull controller", func() {
 			Expect(k8sClient.Create(ctx, app3)).Should(Succeed())
 			Expect(k8sClient.Get(ctx, appKey3, app3)).Should(Succeed())
 
-			mwKey := types.NamespacedName{Name: generateManifestWorkName(app3.GetName(), app3.GetUID()), Namespace: clusterName}
+			mwKey := types.NamespacedName{Name: generateManifestWorkName(app3.GetName(), app3.GetUID()), Namespace: localClusterName}
 			mw := workv1.ManifestWork{}
-			Consistently(func() bool {
-				if err := k8sClient.Get(ctx, mwKey, &mw); err != nil {
-					return true
-				}
-				return false
-			}).Should(BeTrue())
+			Eventually(func() error {
+				return k8sClient.Get(ctx, mwKey, &mw)
+			}).Should(Succeed())
 		})
 	})
 

--- a/propagation-controller/application/helper.go
+++ b/propagation-controller/application/helper.go
@@ -141,7 +141,8 @@ func prepareApplicationForWorkPayload(application *unstructured.Unstructured) un
 		Version: "v1alpha1",
 		Kind:    "Application",
 	})
-	newApp.SetNamespace(application.GetNamespace())
+	targetNamespace := generateAppNamespace(application.GetNamespace(), application.GetAnnotations())
+	newApp.SetNamespace(targetNamespace)
 	newApp.SetName(application.GetName())
 	newApp.SetFinalizers(application.GetFinalizers())
 
@@ -158,7 +159,7 @@ func prepareApplicationForWorkPayload(application *unstructured.Unstructured) un
 			// the user defined destination namespace is respected.
 			// set the resources destination namespace to the app namespace only if the destination namespace is not set
 			if namespace, ok := destination["namespace"].(string); ok && len(namespace) == 0 {
-				destination["namespace"] = application.GetNamespace()
+				destination["namespace"] = targetNamespace
 			}
 			// always set for in-cluster destination
 			destination["server"] = KubernetesInternalAPIServerAddr

--- a/propagation-controller/application/helper_test.go
+++ b/propagation-controller/application/helper_test.go
@@ -434,7 +434,7 @@ func Test_prepareApplicationForWorkPayload(t *testing.T) {
 					"kind":       "Application",
 					"metadata": map[string]interface{}{
 						"name":      "app1",
-						"namespace": "argocd", // the application ns remains regardless of custom namespace from annotation
+						"namespace": "test-ns",
 						"annotations": map[string]interface{}{
 							AnnotationKeyAppRefresh: "normal",
 							"other.annotation":      "preserve-me",

--- a/test/e2e/gitopsaddon/gitopsaddon_embedded_pull_test.go
+++ b/test/e2e/gitopsaddon/gitopsaddon_embedded_pull_test.go
@@ -1,0 +1,112 @@
+//go:build e2e
+
+package gitopsaddon_e2e
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Tests the old (non-argocd-agent) pull model with gitops-addon on local-cluster.
+// The propagation controller creates ManifestWork for local-cluster Applications
+// (previously skipped), and the ArgoCD instance in the local-cluster namespace
+// reconciles the app.
+var _ = Describe("GitOps Addon - Pull Model Propagation on Local-Cluster", Label("embedded-pull"), Ordered, func() {
+	SetDefaultEventuallyTimeout(5 * time.Minute)
+	SetDefaultEventuallyPollingInterval(5 * time.Second)
+
+	var opts gitOpsClusterOpts
+
+	BeforeAll(func() {
+		opts = gitOpsClusterOpts{
+			name:          gitopsClusterName,
+			namespace:     argoCDNamespace,
+			placementName: placementName,
+			agentEnabled:  false,
+		}
+		createBaseResources()
+		createGitOpsCluster(opts)
+	})
+
+	AfterAll(func() {
+		safeCleanup(opts)
+	})
+
+	Context("Spoke and Local-Cluster Setup", func() {
+		It("should create ManagedClusterAddOn and deploy addon on spoke", func() {
+			verifyAddonDeployed(8 * time.Minute)
+		})
+
+		It("should deploy embedded operator on spoke", func() {
+			verifyEmbeddedOperator(5 * time.Minute)
+		})
+
+		It("should deploy ArgoCD CR and application-controller on spoke", func() {
+			verifyArgoCDOnSpoke(8 * time.Minute)
+		})
+
+		It("should create ManagedClusterAddOn for local-cluster", func() {
+			verifyLocalClusterAddon(5 * time.Minute)
+		})
+
+		It("should deploy ArgoCD CR in local-cluster namespace on hub", func() {
+			verifyLocalClusterArgoCDDeployed(8 * time.Minute)
+		})
+	})
+
+	Context("Pull Model Propagation to Local-Cluster", func() {
+		It("should wait for propagation controller to be running", func() {
+			By("waiting for multicloud-integrations deployment (contains propagation controller)")
+			waitForDeploymentReady(hubContext, controllerNamespace, "multicloud-integrations", 3*time.Minute)
+		})
+
+		It("should set up pull model prerequisites on hub", func() {
+			setupPullModelPrerequisites()
+		})
+
+		It("should create ApplicationSet with pull annotations targeting local-cluster", func() {
+			createPullModelApplicationSet()
+		})
+
+		It("should generate Application from ApplicationSet for local-cluster", func() {
+			appName := localClusterName + "-guestbook-pull"
+			By(fmt.Sprintf("waiting for ApplicationSet to generate %s", appName))
+			waitForResourceExists(hubContext, "application", appName, argoCDNamespace, 5*time.Minute)
+		})
+
+		It("should create ManifestWork in local-cluster namespace", func() {
+			verifyPullModelManifestWork(5 * time.Minute)
+		})
+
+		It("should propagate Application to local-cluster namespace and sync guestbook", func() {
+			verifyPullModelGuestbookOnLocalCluster(10 * time.Minute)
+		})
+	})
+
+	Context("Cleanup", func() {
+		It("should clean up pull model resources", func() {
+			cleanupPullModelResources()
+		})
+
+		It("should delete all scenario resources in proper order", func() {
+			scenarioCleanup(opts)
+		})
+	})
+
+	Context("Cleanup Verification", func() {
+		It("should have removed GitOpsCluster and MCAs from hub", func() {
+			verifyHubCleanup(opts)
+		})
+
+		It("should have removed ArgoCD CR and operator from spoke", func() {
+			verifySpokeCleanup()
+		})
+
+		It("should have removed ArgoCD CR from local-cluster namespace on hub", func() {
+			verifyLocalClusterCleanup()
+		})
+	})
+})

--- a/test/e2e/gitopsaddon/helpers_test.go
+++ b/test/e2e/gitopsaddon/helpers_test.go
@@ -1412,3 +1412,263 @@ func safeCleanup(opts gitOpsClusterOpts) {
 	kubectlCtx(hubContext, "delete", "gitopscluster", opts.name, "-n", argoCDNamespace, "--ignore-not-found")
 	deleteLiteral(hubContext, managedClusterSetBindingYAML(argoCDNamespace))
 }
+
+// ---- Pull Model (propagation controller) helpers ----
+// Tests the old non-argocd-agent pull model where the propagation controller
+// creates ManifestWork for Applications with pull annotations/labels.
+
+func pullModelAppSetYAML() string {
+	return fmt.Sprintf(`apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: pull-guestbook-appset
+  namespace: %s
+spec:
+  generators:
+    - clusterDecisionResource:
+        configMapRef: ocm-placement-generator
+        labelSelector:
+          matchLabels:
+            cluster.open-cluster-management.io/placement: %s-pull-local
+        requeueAfterSeconds: 30
+  template:
+    metadata:
+      name: '{{name}}-guestbook-pull'
+      labels:
+        apps.open-cluster-management.io/pull-to-ocm-managed-cluster: 'true'
+      annotations:
+        argocd.argoproj.io/skip-reconcile: 'true'
+        apps.open-cluster-management.io/ocm-managed-cluster: '{{name}}'
+        apps.open-cluster-management.io/ocm-managed-cluster-app-namespace: '%s'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/argoproj/argocd-example-apps
+        targetRevision: HEAD
+        path: guestbook
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: guestbook
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true`, argoCDNamespace, placementName, localClusterName)
+}
+
+func pullModelPlacementYAML() string {
+	return fmt.Sprintf(`apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: %s-pull-local
+  namespace: %s
+spec:
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchLabels:
+          local-cluster: "true"
+  tolerations:
+  - key: cluster.open-cluster-management.io/unreachable
+    operator: Exists
+  - key: cluster.open-cluster-management.io/unavailable
+    operator: Exists`, placementName, argoCDNamespace)
+}
+
+func setupPullModelPrerequisites() {
+	By("granting klusterlet work agent permission to manage ArgoCD resources on hub")
+	Expect(applyLiteral(hubContext, `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: klusterlet-work-argocd
+rules:
+- apiGroups: ["argoproj.io"]
+  resources: ["applications", "appprojects", "applicationsets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]`)).To(Succeed())
+	Expect(applyLiteral(hubContext, `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: klusterlet-work-argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: klusterlet-work-argocd
+subjects:
+- kind: ServiceAccount
+  name: klusterlet-work-sa
+  namespace: open-cluster-management-agent`)).To(Succeed())
+
+	By("creating OCM placement generator ConfigMap for pull model")
+	Expect(applyLiteral(hubContext, fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ocm-placement-generator
+  namespace: %s
+data:
+  apiVersion: cluster.open-cluster-management.io/v1beta1
+  kind: placementdecisions
+  statusListKey: decisions
+  matchKey: clusterName`, argoCDNamespace))).To(Succeed())
+
+	By("creating Placement targeting only local-cluster for pull model")
+	Expect(applyLiteral(hubContext, pullModelPlacementYAML())).To(Succeed())
+
+	By("creating RBAC for ApplicationSet controller to read PlacementDecisions")
+	Expect(applyLiteral(hubContext, `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appset-placement-reader
+rules:
+- apiGroups: ["cluster.open-cluster-management.io"]
+  resources: ["placementdecisions"]
+  verbs: ["get", "list", "watch"]`)).To(Succeed())
+	Expect(applyLiteral(hubContext, fmt.Sprintf(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: appset-placement-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appset-placement-reader
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: %s
+- kind: ServiceAccount
+  name: openshift-gitops-applicationset-controller
+  namespace: %s`, argoCDNamespace, argoCDNamespace))).To(Succeed())
+
+	By("ensuring default AppProject exists in local-cluster namespace")
+	Eventually(func() error {
+		_, err := kubectlCtx(hubContext, "get", "appproject", "default", "-n", localClusterName)
+		if err != nil {
+			return applyLiteral(hubContext, appProjectYAML(localClusterName))
+		}
+		return nil
+	}, 2*time.Minute, 10*time.Second).Should(Succeed())
+
+	By("creating cluster-admin RBAC for local-cluster ArgoCD app-controller")
+	ensureArgoCDClusterAdmin(hubContext, localClusterName)
+
+	By("waiting for ArgoCD app-controller running in local-cluster namespace")
+	waitForPodPhase(hubContext, localClusterName,
+		"app.kubernetes.io/name=acm-openshift-gitops-application-controller", "Running", 5*time.Minute)
+
+	By("verifying Redis is running in local-cluster namespace")
+	waitForPodPhase(hubContext, localClusterName,
+		"app.kubernetes.io/name=acm-openshift-gitops-redis", "Running", 3*time.Minute)
+
+	By("checking PlacementDecision for pull-local placement")
+	Eventually(func(g Gomega) string {
+		out, err := kubectlCtx(hubContext, "get", "placementdecision", "-n", argoCDNamespace,
+			"-l", "cluster.open-cluster-management.io/placement="+placementName+"-pull-local",
+			"-o", "jsonpath={range .items[*]}{.status.decisions[*].clusterName}{end}")
+		g.Expect(err).NotTo(HaveOccurred())
+		return out
+	}, 2*time.Minute, 5*time.Second).Should(ContainSubstring(localClusterName))
+}
+
+func createPullModelApplicationSet() {
+	By("creating pull model ApplicationSet targeting local-cluster")
+	Expect(applyLiteral(hubContext, pullModelAppSetYAML())).To(Succeed())
+}
+
+func verifyPullModelManifestWork(timeout time.Duration) {
+	By("waiting for ManifestWork to be created in local-cluster namespace")
+	Eventually(func(g Gomega) string {
+		out, err := kubectlCtx(hubContext, "get", "manifestwork", "-n", localClusterName,
+			"-o", "jsonpath={range .items[*]}{.metadata.name}{' '}{end}")
+		g.Expect(err).NotTo(HaveOccurred())
+		return out
+	}, timeout, 5*time.Second).Should(ContainSubstring("local-cluster-guestbook-pull"),
+		"ManifestWork for pull model app should exist in local-cluster namespace")
+}
+
+func verifyPullModelGuestbookOnLocalCluster(timeout time.Duration) {
+	appName := localClusterName + "-guestbook-pull"
+
+	By(fmt.Sprintf("waiting for Application %s to appear in local-cluster namespace", appName))
+	waitForResourceExists(hubContext, "applications.argoproj.io",
+		appName, localClusterName, 5*time.Minute)
+
+	By("verifying guestbook-ui deployment on local-cluster (hub)")
+	Eventually(func(g Gomega) int {
+		out, err := kubectlCtx(hubContext, "get", "deployment", "guestbook-ui",
+			"-n", "guestbook",
+			"-o", "jsonpath={.status.availableReplicas}")
+		if err != nil {
+			appInfo, _ := kubectlCtx(hubContext, "get", "applications.argoproj.io", appName,
+				"-n", localClusterName,
+				"-o", "jsonpath=sync={.status.sync.status} health={.status.health.status} dest={.spec.destination.server}")
+			fmt.Fprintf(GinkgoWriter, "  [diag] guestbook-ui not found on hub; app(%s/%s): %s\n",
+				localClusterName, appName, appInfo)
+		}
+		g.Expect(err).NotTo(HaveOccurred())
+		if out == "" {
+			return 0
+		}
+		var n int
+		fmt.Sscanf(out, "%d", &n)
+		return n
+	}, timeout, 10*time.Second).Should(BeNumerically(">", 0))
+
+	By("verifying Application sync status")
+	Eventually(func() string {
+		out, _ := kubectlCtx(hubContext, "get", "applications.argoproj.io", appName,
+			"-n", localClusterName,
+			"-o", "jsonpath={.status.sync.status}")
+		return out
+	}, 3*time.Minute, 10*time.Second).ShouldNot(BeEmpty())
+
+	syncStatus, _ := kubectlCtx(hubContext, "get", "applications.argoproj.io", appName,
+		"-n", localClusterName,
+		"-o", "jsonpath={.status.sync.status}")
+	fmt.Fprintf(GinkgoWriter, "  [info] local-cluster pull model app %s sync status: %s\n",
+		appName, syncStatus)
+}
+
+func cleanupPullModelResources() {
+	By("cleaning up pull model ApplicationSet")
+	kubectlCtx(hubContext, "delete", "applicationset", "pull-guestbook-appset",
+		"-n", argoCDNamespace, "--ignore-not-found")
+
+	By("cleaning up pull model Application from hub (AppSet namespace)")
+	kubectlCtx(hubContext, "delete", "application",
+		localClusterName+"-guestbook-pull",
+		"-n", argoCDNamespace, "--ignore-not-found")
+
+	By("cleaning up pull model Application from local-cluster namespace")
+	kubectlCtx(hubContext, "delete", "applications.argoproj.io",
+		localClusterName+"-guestbook-pull",
+		"-n", localClusterName, "--ignore-not-found")
+
+	By("cleaning up ManifestWork for pull model in local-cluster namespace")
+	kubectlCtx(hubContext, "delete", "manifestwork", "-n", localClusterName,
+		"-l", "apps.open-cluster-management.io/application-set=true",
+		"--ignore-not-found")
+
+	By("cleaning up pull model Placement")
+	kubectlCtx(hubContext, "delete", "placement",
+		placementName+"-pull-local",
+		"-n", argoCDNamespace, "--ignore-not-found")
+
+	By("cleaning up OCM placement generator ConfigMap")
+	kubectlCtx(hubContext, "delete", "configmap", "ocm-placement-generator",
+		"-n", argoCDNamespace, "--ignore-not-found")
+
+	By("cleaning up RBAC for pull model")
+	kubectlCtx(hubContext, "delete", "clusterrolebinding", "appset-placement-reader", "--ignore-not-found")
+	kubectlCtx(hubContext, "delete", "clusterrole", "appset-placement-reader", "--ignore-not-found")
+	kubectlCtx(hubContext, "delete", "clusterrolebinding", "klusterlet-work-argocd", "--ignore-not-found")
+	kubectlCtx(hubContext, "delete", "clusterrole", "klusterlet-work-argocd", "--ignore-not-found")
+
+	By("cleaning up guestbook resources on hub")
+	kubectlCtx(hubContext, "delete", "applications.argoproj.io", "guestbook",
+		"-n", localClusterName, "--ignore-not-found")
+	kubectlCtx(hubContext, "delete", "appproject", "default",
+		"-n", localClusterName, "--ignore-not-found")
+	kubectlCtx(hubContext, "delete", "namespace", "guestbook", "--ignore-not-found", "--wait=false")
+	kubectlCtx(hubContext, "delete", "clusterrolebinding",
+		"acm-openshift-gitops-cluster-admin", "--ignore-not-found")
+}


### PR DESCRIPTION
Remove the isLocalCluster check that was skipping ManifestWork creation for local-cluster Applications. With gitops-addon now deploying ArgoCD into the local-cluster namespace, the propagation controller can create ManifestWork there and ArgoCD will reconcile apps locally.

Changes:
- Remove isLocalCluster gate and dead code from propagation controller
- Use generateAppNamespace in prepareApplicationForWorkPayload to honor the ocm-managed-cluster-app-namespace annotation
- Update unit tests to expect ManifestWork creation for local-cluster
- Add e2e test (embedded-pull) validating full flow: AppSet → Application → ManifestWork → propagated Application in local-cluster → guestbook deployed and synced
- Add Makefile targets: test-e2e-gitopsaddon-embedded-pull, test-local-e2e-gitopsaddon-embedded-pull

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for GitOps addon embedded-pull propagation targeting local-cluster
  * Honor namespace annotation for generated applications

* **Bug Fixes**
  * Ensure pull-annotated applications on local-cluster are propagated (ManifestWork created)

* **Tests**
  * Added end-to-end test suite for embedded-pull propagation
  * Added pull-model E2E test helpers and cleanup routines
<!-- end of auto-generated comment: release notes by coderabbit.ai -->