### PR TITLE
[main] Bump moby/spdystream to v0.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,4 +119,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
-replace github.com/moby/spdystream v0.5.0 => github.com/moby/spdystream v0.5.1
+replace github.com/moby/spdystream => github.com/moby/spdystream v0.5.1

--- a/go.mod
+++ b/go.mod
@@ -118,3 +118,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/yaml v1.6.0
 )
+
+replace github.com/moby/spdystream v0.5.0 => github.com/moby/spdystream v0.5.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned a third-party dependency to a specific patch version to ensure consistent builds and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->