### PR TITLE
clean up old argocd cluster secrets only if they are not referred by …

### DIFF
--- a/pkg/controller/gitopscluster/gitopscluster_controller_test.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -1293,41 +1294,48 @@ func TestReconcileGitOpsClusterAgentMode(t *testing.T) {
 						},
 					},
 				},
-				// Pre-create the traditional cluster secret that the controller would create
-				&v1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cluster1-gitops-cluster",
-						Namespace: "argocd",
-						Labels: map[string]string{
-							argoCDTypeLabel: argoCDSecretTypeClusterValue,
-							"apps.open-cluster-management.io/acm-cluster":    "true",
-							"apps.open-cluster-management.io/cluster-name":   "cluster1",
-							"apps.open-cluster-management.io/cluster-server": "cluster1-server",
-						},
-					},
-					Data: map[string][]byte{
-						"server": []byte("https://cluster1-server"),
-						"name":   []byte("cluster1"),
+			// Pre-existing legacy secret (old naming convention, different server URL).
+			// With safe-mode cleanup, this should be deleted because no ArgoCD Applications
+			// reference its server URL.
+			&v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster1-gitops-cluster",
+					Namespace: "argocd",
+					Labels: map[string]string{
+						argoCDTypeLabel: argoCDSecretTypeClusterValue,
+						"apps.open-cluster-management.io/acm-cluster":    "true",
+						"apps.open-cluster-management.io/cluster-name":   "cluster1",
+						"apps.open-cluster-management.io/cluster-server": "cluster1-server",
 					},
 				},
-				createTestArgoCDServerService("argocd"),
-				createTestArgoCDServerPod("argocd"),
-				// Note: CA secret is now self-generated via certrotation, no source secret needed
+				Data: map[string][]byte{
+					"server": []byte("https://cluster1-server"),
+					"name":   []byte("cluster1"),
+				},
 			},
-			expectedCondition: string(metav1.ConditionTrue),
-			expectedReason:    gitopsclusterV1beta1.ReasonSuccess,
-			expectedMessage:   "Successfully registered 1 managed clusters to ArgoCD",
-			validateFunc: func(t *testing.T, c client.Client) {
-				// Verify traditional cluster secret was created (without agent labels)
-				secret := &v1.Secret{}
-				err := c.Get(context.TODO(), types.NamespacedName{Name: "cluster1-gitops-cluster", Namespace: "argocd"}, secret)
-				assert.NoError(t, err)
-				assert.Equal(t, "cluster", secret.Labels[argoCDTypeLabel])
-				// Should NOT have agent mapping label
-				_, hasAgentLabel := secret.Labels[labelKeyClusterAgentMapping]
-				assert.False(t, hasAgentLabel)
-			},
+			createTestArgoCDServerService("argocd"),
+			createTestArgoCDServerPod("argocd"),
+			// Note: CA secret is now self-generated via certrotation, no source secret needed
 		},
+		expectedCondition: string(metav1.ConditionTrue),
+		expectedReason:    gitopsclusterV1beta1.ReasonSuccess,
+		expectedMessage:   "Successfully registered 1 managed clusters to ArgoCD",
+		validateFunc: func(t *testing.T, c client.Client) {
+			// Verify the new blank pull-model secret was created (without agent labels)
+			secret := &v1.Secret{}
+			err := c.Get(context.TODO(), types.NamespacedName{Name: "cluster1-application-manager-cluster-secret", Namespace: "argocd"}, secret)
+			assert.NoError(t, err)
+			assert.Equal(t, "cluster", secret.Labels[argoCDTypeLabel])
+			// Should NOT have agent mapping label
+			_, hasAgentLabel := secret.Labels[labelKeyClusterAgentMapping]
+			assert.False(t, hasAgentLabel)
+
+			// The old legacy secret should have been safe-deleted (different URL, no Apps reference it)
+			oldSecret := &v1.Secret{}
+			getErr := c.Get(context.TODO(), types.NamespacedName{Name: "cluster1-gitops-cluster", Namespace: "argocd"}, oldSecret)
+			assert.True(t, k8errors.IsNotFound(getErr), "legacy secret cluster1-gitops-cluster should have been safe-deleted")
+		},
+	},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controller/gitopscluster/import_clusters.go
+++ b/pkg/controller/gitopscluster/import_clusters.go
@@ -30,14 +30,16 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	spokeclusterv1 "open-cluster-management.io/api/cluster/v1"
+	authv1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 	gitopsclusterV1beta1 "open-cluster-management.io/multicloud-integrations/pkg/apis/apps/v1beta1"
 	"open-cluster-management.io/multicloud-integrations/pkg/utils"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	authv1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -595,10 +597,15 @@ func (r *ReconcileGitOpsCluster) createBlankClusterSecret(
 }
 
 // cleanupOldArgoClusterSecrets lists all ACM-managed ArgoCD cluster secrets for the given
-// managed cluster and deletes any that are stale (different name, same server URL as the new
-// secret, not an agent-mode secret). Only secrets whose server URL matches the new secret are
-// deleted — if the server URL differs the old secret may still be referenced by ArgoCD
-// Applications, and deleting it could cause those Applications to be removed by ArgoCD.
+// managed cluster and deletes stale ones (different name, not an agent-mode secret).
+//
+// Two deletion strategies are applied:
+//  1. Same server URL as the new secret → unconditionally deleted (safe: ArgoCD resolves to
+//     the same endpoint so no existing Application destinations break).
+//  2. Different server URL → "safe-mode" deletion: the secret is removed only when no ArgoCD
+//     Application in the namespace explicitly references the old server URL via
+//     spec.destination.server. If any Application still points to that URL the secret is
+//     preserved to prevent ArgoCD from deleting or erroring on those Applications.
 func (r *ReconcileGitOpsCluster) cleanupOldArgoClusterSecrets(newSecret *v1.Secret, managedClusterName string) {
 	secretList := &v1.SecretList{}
 
@@ -635,6 +642,7 @@ func (r *ReconcileGitOpsCluster) cleanupOldArgoClusterSecrets(newSecret *v1.Secr
 	for i := range secretList.Items {
 		oldSecret := &secretList.Items[i]
 
+		// Skip the new secret
 		if oldSecret.Name == newSecret.Name {
 			continue
 		}
@@ -645,17 +653,26 @@ func (r *ReconcileGitOpsCluster) cleanupOldArgoClusterSecrets(newSecret *v1.Secr
 			continue
 		}
 
-		// Only delete if the server URL matches the new secret. A different server URL means the
-		// old secret points to a different cluster endpoint that ArgoCD Applications may still
-		// reference — deleting it could cause ArgoCD to remove those Applications.
 		oldServer := string(oldSecret.Data["server"])
-		if oldServer != newServer {
-			klog.Infof("Skipping deletion of %s/%s: server URL %q differs from new secret %q — Applications may still reference it",
-				oldSecret.Namespace, oldSecret.Name, oldServer, newServer)
-			continue
-		}
+		oldClusterName := string(oldSecret.Data["name"])
 
-		klog.Infof("Cleaning up old ArgoCD cluster secret %s/%s (replaced by %s)", oldSecret.Namespace, oldSecret.Name, newSecret.Name)
+		if oldServer != newServer {
+			// Safe-mode: the old secret points to a different endpoint. Only delete if no
+			// ArgoCD Application explicitly references the old server URL via
+			// spec.destination.server. A destination.name reference resolves through the
+			// cluster registry: because the new secret registers the same cluster name, ArgoCD
+			// will continue to find the cluster after the old secret is removed — so
+			// destination.name references do NOT prevent deletion.
+			if r.isOldSecretReferencedByArgoApps(newSecret.Namespace, oldServer) {
+				klog.Infof("Skipping deletion of %s/%s: cluster %q / server URL %q is still referenced via spec.destination.server by ArgoCD Applications",
+					oldSecret.Namespace, oldSecret.Name, oldClusterName, oldServer)
+				continue
+			}
+			klog.Infof("Safe-deleting old ArgoCD cluster secret %s/%s: cluster %q / server URL %q not referenced by any Application (replaced by %s)",
+				oldSecret.Namespace, oldSecret.Name, oldClusterName, oldServer, newSecret.Name)
+		} else {
+			klog.Infof("Cleaning up old ArgoCD cluster secret %s/%s (replaced by %s)", oldSecret.Namespace, oldSecret.Name, newSecret.Name)
+		}
 
 		if err := r.Delete(context.TODO(), oldSecret); err != nil {
 			klog.Warningf("Failed to delete old ArgoCD cluster secret %s/%s: %v", oldSecret.Namespace, oldSecret.Name, err)
@@ -663,6 +680,45 @@ func (r *ReconcileGitOpsCluster) cleanupOldArgoClusterSecrets(newSecret *v1.Secr
 			klog.Infof("Successfully cleaned up old ArgoCD cluster secret %s/%s", oldSecret.Namespace, oldSecret.Name)
 		}
 	}
+}
+
+// isOldSecretReferencedByArgoApps reports whether any ArgoCD Application in the given namespace
+// has spec.destination.server equal to serverURL.
+//
+// Only the explicit server-URL reference is checked. A destination.name reference resolves
+// through ArgoCD's cluster registry: because the new secret registers the same cluster name,
+// ArgoCD continues to find the cluster after the old secret is removed. Preserving an old
+// secret solely because of destination.name references would prevent the cleanup that fixes the
+// "2 clusters with the same name" error caused by having both old and new secrets present.
+//
+// If the ArgoCD Application CRD is not installed (no-match error) the function returns false —
+// there can be no Applications referencing the secret, so deletion is safe.
+// For all other listing errors it returns true (fail-safe: do not delete).
+func (r *ReconcileGitOpsCluster) isOldSecretReferencedByArgoApps(namespace, serverURL string) bool {
+	appList := &unstructured.UnstructuredList{}
+	appList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+		Kind:    "ApplicationList",
+	})
+
+	if err := r.List(context.TODO(), appList, &client.ListOptions{Namespace: namespace}); err != nil {
+		if meta.IsNoMatchError(err) {
+			// ArgoCD Application CRD is not installed — no Applications can reference the secret.
+			return false
+		}
+		klog.Warningf("Failed to list ArgoCD Applications in namespace %s: %v — treating old secret as referenced", namespace, err)
+		return true
+	}
+
+	for i := range appList.Items {
+		destServer, _, _ := unstructured.NestedString(appList.Items[i].Object, "spec", "destination", "server")
+		if destServer == serverURL {
+			return true
+		}
+	}
+
+	return false
 }
 
 // cleanupOldClusterSecrets removes old cluster secrets from the managed cluster namespace

--- a/pkg/controller/gitopscluster/import_clusters_test.go
+++ b/pkg/controller/gitopscluster/import_clusters_test.go
@@ -24,7 +24,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	spokeclusterv1 "open-cluster-management.io/api/cluster/v1"
 	authv1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
@@ -2730,7 +2732,7 @@ func TestCleanupOldArgoClusterSecrets(t *testing.T) {
 		}
 	}
 
-	// acmSecret creates a persisted ACM-managed ArgoCD cluster secret (server in Data).
+	// acmSecret creates a persisted ACM-managed ArgoCD cluster secret (server and name in Data).
 	acmSecret := func(name, serverURL string, extraLabels ...map[string]string) *v1.Secret {
 		s := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2744,6 +2746,7 @@ func TestCleanupOldArgoClusterSecrets(t *testing.T) {
 			},
 			Data: map[string][]byte{
 				"server": []byte(serverURL),
+				"name":   []byte(clusterName),
 			},
 		}
 		for _, extra := range extraLabels {
@@ -2779,10 +2782,40 @@ func TestCleanupOldArgoClusterSecrets(t *testing.T) {
 		}
 	}
 
+	// argoApp creates an ArgoCD Application unstructured object with the given destination server.
+	argoApp := func(name, destServer string) client.Object {
+		app := &unstructured.Unstructured{}
+		app.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "argoproj.io",
+			Version: "v1alpha1",
+			Kind:    "Application",
+		})
+		app.SetName(name)
+		app.SetNamespace(argoNs)
+		_ = unstructured.SetNestedField(app.Object, destServer, "spec", "destination", "server")
+		return app
+	}
+
+	// argoAppByName creates an ArgoCD Application that references a cluster via destination.name.
+	argoAppByName := func(name, destClusterName string) client.Object {
+		app := &unstructured.Unstructured{}
+		app.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "argoproj.io",
+			Version: "v1alpha1",
+			Kind:    "Application",
+		})
+		app.SetName(name)
+		app.SetNamespace(argoNs)
+		_ = unstructured.SetNestedField(app.Object, destClusterName, "spec", "destination", "name")
+		return app
+	}
+
 	tests := []struct {
 		name            string
 		newSecret       *v1.Secret
 		existingSecrets []client.Object
+		// ArgoCD Application objects present in the namespace
+		existingApps []client.Object
 		// names of secrets expected to survive (not be deleted)
 		expectedSurvive []string
 		// names of secrets expected to be deleted
@@ -2826,11 +2859,27 @@ func TestCleanupOldArgoClusterSecrets(t *testing.T) {
 			expectedDeleted: []string{"test-cluster-cluster-secret", "test-cluster-old-msa-cluster-secret"},
 		},
 		{
-			name:      "old secret with different server URL (proxy vs direct) - NOT deleted to protect Apps",
+			name:      "old secret with different server URL and no apps referencing it - safe-deleted",
 			newSecret: newSecret("test-cluster-application-manager-cluster-secret", proxyURL),
 			existingSecrets: []client.Object{
 				acmSecret("test-cluster-application-manager-cluster-secret", proxyURL),
 				acmSecret("test-cluster-cluster-secret", directURL),
+			},
+			existingApps: []client.Object{},
+			expectedSurvive: []string{
+				"test-cluster-application-manager-cluster-secret",
+			},
+			expectedDeleted: []string{"test-cluster-cluster-secret"},
+		},
+		{
+			name:      "old secret with different server URL referenced by ArgoCD App - preserved",
+			newSecret: newSecret("test-cluster-application-manager-cluster-secret", proxyURL),
+			existingSecrets: []client.Object{
+				acmSecret("test-cluster-application-manager-cluster-secret", proxyURL),
+				acmSecret("test-cluster-cluster-secret", directURL),
+			},
+			existingApps: []client.Object{
+				argoApp("my-app", directURL),
 			},
 			expectedSurvive: []string{
 				"test-cluster-application-manager-cluster-secret",
@@ -2839,18 +2888,106 @@ func TestCleanupOldArgoClusterSecrets(t *testing.T) {
 			expectedDeleted: []string{},
 		},
 		{
-			name:      "mixed: same-URL old secret deleted, different-URL old secret preserved",
+			name:      "old secret with different server URL and app referencing different URL - safe-deleted",
 			newSecret: newSecret("test-cluster-application-manager-cluster-secret", proxyURL),
 			existingSecrets: []client.Object{
 				acmSecret("test-cluster-application-manager-cluster-secret", proxyURL),
-				acmSecret("test-cluster-old-proxy-cluster-secret", proxyURL),  // same URL — safe to delete
-				acmSecret("test-cluster-cluster-secret", directURL),           // different URL — keep it
+				acmSecret("test-cluster-cluster-secret", directURL),
+			},
+			existingApps: []client.Object{
+				argoApp("my-app", "https://some-other-cluster.example.com:6443"),
+			},
+			expectedSurvive: []string{
+				"test-cluster-application-manager-cluster-secret",
+			},
+			expectedDeleted: []string{"test-cluster-cluster-secret"},
+		},
+		{
+			name:      "mixed: same-URL old secret deleted, different-URL old secret safe-deleted when no apps reference it",
+			newSecret: newSecret("test-cluster-application-manager-cluster-secret", proxyURL),
+			existingSecrets: []client.Object{
+				acmSecret("test-cluster-application-manager-cluster-secret", proxyURL),
+				acmSecret("test-cluster-old-proxy-cluster-secret", proxyURL), // same URL — safe to delete
+				acmSecret("test-cluster-cluster-secret", directURL),          // different URL — safe-deleted (no apps reference it)
+			},
+			existingApps: []client.Object{},
+			expectedSurvive: []string{
+				"test-cluster-application-manager-cluster-secret",
+			},
+			expectedDeleted: []string{"test-cluster-old-proxy-cluster-secret", "test-cluster-cluster-secret"},
+		},
+		{
+			name:      "mixed: same-URL old secret deleted, different-URL old secret preserved when app references it",
+			newSecret: newSecret("test-cluster-application-manager-cluster-secret", proxyURL),
+			existingSecrets: []client.Object{
+				acmSecret("test-cluster-application-manager-cluster-secret", proxyURL),
+				acmSecret("test-cluster-old-proxy-cluster-secret", proxyURL), // same URL — safe to delete
+				acmSecret("test-cluster-cluster-secret", directURL),          // different URL — preserved (app references it)
+			},
+			existingApps: []client.Object{
+				argoApp("my-app", directURL),
 			},
 			expectedSurvive: []string{
 				"test-cluster-application-manager-cluster-secret",
 				"test-cluster-cluster-secret",
 			},
 			expectedDeleted: []string{"test-cluster-old-proxy-cluster-secret"},
+		},
+		{
+			// destination.name references resolve through ArgoCD's cluster registry: the new
+			// secret already registers the same cluster name, so ArgoCD can still find the
+			// cluster after the old secret is removed. The old secret is therefore safe to delete,
+			// which also fixes the "2 clusters with the same name" ArgoCD error.
+			name:      "old secret with different server URL referenced only via destination.name - safe-deleted",
+			newSecret: newSecret("test-cluster-application-manager-cluster-secret", proxyURL),
+			existingSecrets: []client.Object{
+				acmSecret("test-cluster-application-manager-cluster-secret", proxyURL),
+				acmSecret("test-cluster-cluster-secret", directURL),
+			},
+			existingApps: []client.Object{
+				argoAppByName("my-app", clusterName),
+			},
+			expectedSurvive: []string{
+				"test-cluster-application-manager-cluster-secret",
+			},
+			expectedDeleted: []string{"test-cluster-cluster-secret"},
+		},
+		{
+			name:      "old secret with different server URL referenced via destination.name with unrelated cluster name - safe-deleted",
+			newSecret: newSecret("test-cluster-application-manager-cluster-secret", proxyURL),
+			existingSecrets: []client.Object{
+				acmSecret("test-cluster-application-manager-cluster-secret", proxyURL),
+				acmSecret("test-cluster-cluster-secret", directURL),
+			},
+			existingApps: []client.Object{
+				argoAppByName("my-app", "some-other-cluster"),
+			},
+			expectedSurvive: []string{
+				"test-cluster-application-manager-cluster-secret",
+			},
+			expectedDeleted: []string{"test-cluster-cluster-secret"},
+		},
+		{
+			// An app using destination.name does not prevent deletion because the new secret
+			// covers the same cluster name. An app using destination.server with the old direct
+			// URL does prevent deletion (explicit URL reference would break that app).
+			name:      "mixed: app using destination.name does not block deletion; app using destination.server does",
+			newSecret: newSecret("test-cluster-application-manager-cluster-secret", proxyURL),
+			existingSecrets: []client.Object{
+				acmSecret("test-cluster-application-manager-cluster-secret", proxyURL),
+				acmSecret("test-cluster-old-proxy-cluster-secret", proxyURL), // same URL — unconditional delete
+				acmSecret("test-cluster-cluster-secret", directURL),          // different URL — preserved (app uses destination.server)
+				acmSecret("test-cluster-other-old-secret", directURL+"/v2"),  // different URL — safe-deleted (only destination.name app)
+			},
+			existingApps: []client.Object{
+				argoApp("server-app", directURL),       // explicitly references old directURL → preserve test-cluster-cluster-secret
+				argoAppByName("name-app", clusterName), // cluster-name ref → does NOT block deletion of test-cluster-other-old-secret
+			},
+			expectedSurvive: []string{
+				"test-cluster-application-manager-cluster-secret",
+				"test-cluster-cluster-secret",
+			},
+			expectedDeleted: []string{"test-cluster-old-proxy-cluster-secret", "test-cluster-other-old-secret"},
 		},
 		{
 			name:      "agent-mode secret coexists - not deleted regardless of server URL",
@@ -2920,9 +3057,10 @@ func TestCleanupOldArgoClusterSecrets(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			objects := append(tt.existingSecrets, tt.existingApps...)
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
-				WithObjects(tt.existingSecrets...).
+				WithObjects(objects...).
 				Build()
 
 			reconciler := &ReconcileGitOpsCluster{


### PR DESCRIPTION
…any application

https://redhat.atlassian.net/browse/ACM-32872

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster secret cleanup to safely preserve secrets that are still referenced by ArgoCD applications.

* **Tests**
  * Enhanced test coverage for cluster secret cleanup scenarios with ArgoCD application references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->