### PR TITLE
gitopscluster controller sync up argocd cluster secret once its MSA t…

### DIFF
--- a/cmd/gitopscluster/exec/manager.go
+++ b/cmd/gitopscluster/exec/manager.go
@@ -76,7 +76,13 @@ func RunManager() {
 		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 			opts.ByObject = map[client.Object]cache.ByObject{
 				&v1.Secret{}: {
-					Label: labels.SelectorFromSet(labels.Set{"apps.open-cluster-management.io/cluster-name,argocd.argoproj.io/secret-type": "cluster"}),
+					// Watch only ArgoCD cluster secrets (written by this controller into the
+					// ArgoCD server namespace). The original selector used a single key
+					// containing a comma — "cluster-name,argocd.argoproj.io/secret-type" —
+					// which is not a valid Kubernetes label key. We use the canonical ArgoCD
+					// cluster-secret label instead. MSA token secrets are watched through a
+					// separate cache in the controller's add() function (Fix 3).
+					Label: labels.SelectorFromSet(labels.Set{"argocd.argoproj.io/secret-type": "cluster"}),
 				},
 				&appsv1.Deployment{}: {
 					Label: labels.SelectorFromSet(labels.Set{"app.kubernetes.io/component": "principal"}),

--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -26,6 +26,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 	spokeclusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -39,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	authv1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -96,6 +98,12 @@ var errInvalidPlacementRef = errors.New("invalid placement reference")
 const (
 	clusterSecretSuffix = "-cluster-secret"
 	maxStatusMsgLen     = 128 * 1024
+
+	// msaTokenSecretLabelKey is the label placed on hub-side secrets that carry a managed
+	// service-account token. The managed-serviceaccount addon agent sets this label on every
+	// secret it creates or refreshes, making it the reliable selector for the MSA token
+	// secret watch (Fix 3).
+	msaTokenSecretLabelKey = "authentication.open-cluster-management.io/is-managed-serviceaccount"
 )
 
 // newReconciler returns a new reconcile.Reconciler
@@ -232,7 +240,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			return err
 		}
 
-		// Watch changes to Managed service account's tokenSecretRef
+		// Watch changes to Managed service account's tokenSecretRef and ExpirationTimestamp.
 		if utils.IsReadyManagedServiceAccount(mgr.GetAPIReader()) {
 			err = c.Watch(
 				source.Kind(
@@ -240,6 +248,50 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 					&authv1beta1.ManagedServiceAccount{},
 					&handler.TypedEnqueueRequestForObject[*authv1beta1.ManagedServiceAccount]{},
 					utils.ManagedServiceAccountPredicateFunc,
+				),
+			)
+			if err != nil {
+				return err
+			}
+
+			// Watch MSA token secret content changes for in-place token refreshes (Fix 3).
+			//
+			// The MSA addon agent refreshes tokens in-place: the secret name in
+			// Status.TokenSecretRef stays the same but the token bytes (and
+			// LastRefreshTimestamp) are updated. The MSA object watch above catches
+			// LastRefreshTimestamp changes (Fix 2), but we add a direct secret watch here
+			// as an additional layer of defence.
+			//
+			// MSA token secrets carry the label
+			// "authentication.open-cluster-management.io/is-managed-serviceaccount=true".
+			// We create a secondary cache scoped to that label so we do not watch every
+			// secret in the cluster. The secondary cache is registered with the manager so
+			// it is started and synced alongside the primary cache.
+			msaTokenCache, cacheErr := cache.New(mgr.GetConfig(), cache.Options{
+				Scheme: mgr.GetScheme(),
+				Mapper: mgr.GetRESTMapper(),
+				ByObject: map[client.Object]cache.ByObject{
+					&v1.Secret{}: {
+						Label: labels.SelectorFromSet(labels.Set{
+							msaTokenSecretLabelKey: "true",
+						}),
+					},
+				},
+			})
+			if cacheErr != nil {
+				return fmt.Errorf("failed to create MSA token secret cache: %w", cacheErr)
+			}
+
+			if err = mgr.Add(msaTokenCache); err != nil {
+				return fmt.Errorf("failed to register MSA token secret cache with manager: %w", err)
+			}
+
+			err = c.Watch(
+				source.Kind(
+					msaTokenCache,
+					&v1.Secret{},
+					&handler.TypedEnqueueRequestForObject[*v1.Secret]{},
+					utils.MSATokenSecretPredicateFunc,
 				),
 			)
 			if err != nil {
@@ -336,7 +388,12 @@ func (r *ReconcileGitOpsCluster) Reconcile(ctx context.Context, request reconcil
 		return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(returnRequeueInterval) * time.Minute}, returnErr
 	}
 
-	return reconcile.Result{}, nil
+	// Periodic requeue ensures credentials are refreshed even when watch events are missed
+	// (e.g. missed MSA token rotation events under hub cluster load). This acts as a safety
+	// net on top of the event-driven watches and is especially important during MSA token
+	// rotation, where a missed event would otherwise leave ArgoCD with a stale token for up
+	// to the rotation interval (default 7 days).
+	return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 }
 
 func (r *ReconcileGitOpsCluster) cleanupOrphanSecrets(orphanGitOpsClusterSecretList map[types.NamespacedName]string) bool {

--- a/pkg/controller/gitopscluster/gitopscluster_controller_test.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1068,7 +1069,7 @@ func TestReconcileRequest(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.Equal(t, reconcile.Result{}, result)
+		assert.Equal(t, reconcile.Result{RequeueAfter: 5 * time.Minute}, result)
 	})
 }
 

--- a/pkg/controller/gitopscluster/import_clusters.go
+++ b/pkg/controller/gitopscluster/import_clusters.go
@@ -606,6 +606,17 @@ func (r *ReconcileGitOpsCluster) createBlankClusterSecret(
 //     Application in the namespace explicitly references the old server URL via
 //     spec.destination.server. If any Application still points to that URL the secret is
 //     preserved to prevent ArgoCD from deleting or erroring on those Applications.
+//
+// In both cases, before the physical deletion the ArgoCD cluster-type label
+// (argocd.argoproj.io/secret-type=cluster) is removed from the old secret via a
+// patch. This prevents the ArgoCD ApplicationSet controller's clusterSecretEventHandler
+// from enqueueing ApplicationSets on the subsequent DELETE event before the new
+// secret has propagated into ArgoCD's informer cache. Without this step, the cluster
+// generator would momentarily see zero clusters for the managed cluster and delete the
+// corresponding ArgoCD Application (which then gets re-created, losing its sync history
+// and causing all managed resources to appear "untracked" until a manual sync).
+// If the de-label patch fails the deletion is skipped; the secret will be retried on
+// the next reconcile.
 func (r *ReconcileGitOpsCluster) cleanupOldArgoClusterSecrets(newSecret *v1.Secret, managedClusterName string) {
 	secretList := &v1.SecretList{}
 
@@ -674,8 +685,41 @@ func (r *ReconcileGitOpsCluster) cleanupOldArgoClusterSecrets(newSecret *v1.Secr
 			klog.Infof("Cleaning up old ArgoCD cluster secret %s/%s (replaced by %s)", oldSecret.Namespace, oldSecret.Name, newSecret.Name)
 		}
 
-		if err := r.Delete(context.TODO(), oldSecret); err != nil {
-			klog.Warningf("Failed to delete old ArgoCD cluster secret %s/%s: %v", oldSecret.Namespace, oldSecret.Name, err)
+		// De-label before deleting: remove the ArgoCD cluster-type label so that ArgoCD's
+		// clusterSecretEventHandler does not fire an ApplicationSet reconcile when the DELETE
+		// event is processed. Without this step the ApplicationSet cluster generator can
+		// momentarily see zero entries for the managed cluster (new secret not yet in cache)
+		// and delete the corresponding Application — causing all managed resources to lose
+		// their ArgoCD tracking until a manual sync.
+		deLabeled := oldSecret.DeepCopy()
+		delete(deLabeled.Labels, "argocd.argoproj.io/secret-type")
+		if patchErr := r.Patch(context.TODO(), deLabeled, client.MergeFrom(oldSecret)); patchErr != nil {
+			if !k8errors.IsNotFound(patchErr) {
+				klog.Warningf("Failed to de-label old ArgoCD cluster secret %s/%s before deletion (skipping to avoid race condition): %v",
+					oldSecret.Namespace, oldSecret.Name, patchErr)
+				continue
+			}
+			// Already gone — nothing to delete.
+			klog.Infof("Old ArgoCD cluster secret %s/%s already deleted", oldSecret.Namespace, oldSecret.Name)
+			continue
+		}
+
+		if err := r.Delete(context.TODO(), deLabeled); err != nil {
+			if !k8errors.IsNotFound(err) {
+				// Delete failed — restore the ArgoCD cluster-type label so the secret
+				// remains visible to future reconciles. Without this, the cleanup selector
+				// (argocd.argoproj.io/secret-type=cluster) would never find the secret
+				// again and it would be orphaned indefinitely.
+				relabeled := deLabeled.DeepCopy()
+				relabeled.Labels["argocd.argoproj.io/secret-type"] = "cluster"
+				if relabelErr := r.Patch(context.TODO(), relabeled, client.MergeFrom(deLabeled)); relabelErr != nil {
+					klog.Warningf("Failed to restore ArgoCD label on %s/%s after delete failure (secret may be orphaned): %v",
+						oldSecret.Namespace, oldSecret.Name, relabelErr)
+				} else {
+					klog.Warningf("Restored ArgoCD label on %s/%s after delete failure; will retry on next reconcile: %v",
+						oldSecret.Namespace, oldSecret.Name, err)
+				}
+			}
 		} else {
 			klog.Infof("Successfully cleaned up old ArgoCD cluster secret %s/%s", oldSecret.Namespace, oldSecret.Name)
 		}

--- a/pkg/controller/gitopscluster/import_clusters_test.go
+++ b/pkg/controller/gitopscluster/import_clusters_test.go
@@ -3154,6 +3154,111 @@ func TestCleanupOldArgoClusterSecrets(t *testing.T) {
 	}
 }
 
+// TestCleanupOldArgoClusterSecrets_DeLabelBeforeDelete verifies that the
+// argocd.argoproj.io/secret-type label is removed from the old secret before it is
+// physically deleted. This is the fix for the race condition where ArgoCD's
+// clusterSecretEventHandler fires on the DELETE event before the new cluster secret
+// has propagated into ArgoCD's informer cache, causing the ApplicationSet cluster
+// generator to see zero clusters and delete the corresponding Application.
+func TestCleanupOldArgoClusterSecrets_DeLabelBeforeDelete(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1.AddToScheme(scheme), "adding corev1 to scheme should succeed")
+
+	argoNs := "argocd"
+	clusterName := "test-cluster"
+	directURL := "https://api.test-cluster.example.com:6443"
+	proxyURL := "https://cluster-proxy.multicluster-engine.svc.cluster.local:9092/test-cluster"
+
+	// old secret that will be replaced (different name → triggers cleanup)
+	oldSecretName := "test-cluster-cluster-secret"
+	oldSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oldSecretName,
+			Namespace: argoNs,
+			Labels: map[string]string{
+				"argocd.argoproj.io/secret-type":                 "cluster",
+				"apps.open-cluster-management.io/acm-cluster":    "true",
+				"apps.open-cluster-management.io/cluster-name":   clusterName,
+				"apps.open-cluster-management.io/cluster-server": "api.test-cluster.example.com",
+			},
+		},
+		Data: map[string][]byte{
+			"server": []byte(directURL),
+			"name":   []byte(clusterName),
+		},
+	}
+
+	// new secret (different name, different URL — would have triggered safe-delete check)
+	newSecretObj := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-application-manager-cluster-secret",
+			Namespace: argoNs,
+			Labels: map[string]string{
+				"argocd.argoproj.io/secret-type":               "cluster",
+				"apps.open-cluster-management.io/acm-cluster":  "true",
+				"apps.open-cluster-management.io/cluster-name": clusterName,
+			},
+		},
+		Data: map[string][]byte{
+			"server": []byte(proxyURL),
+			"name":   []byte(clusterName),
+		},
+	}
+
+	// Track Patch calls via a wrapper so we can assert the label was stripped.
+	type patchRecord struct {
+		name   string
+		labels map[string]string
+	}
+	var patchedSecrets []patchRecord
+
+	trackingClient := &patchTrackingClient{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(oldSecret, newSecretObj).
+			Build(),
+		onPatch: func(obj client.Object) {
+			s, ok := obj.(*v1.Secret)
+			if !ok {
+				return
+			}
+			labels := make(map[string]string)
+			for k, v := range s.GetLabels() {
+				labels[k] = v
+			}
+			patchedSecrets = append(patchedSecrets, patchRecord{name: s.Name, labels: labels})
+		},
+	}
+
+	reconciler := &ReconcileGitOpsCluster{Client: trackingClient}
+	reconciler.cleanupOldArgoClusterSecrets(newSecretObj, clusterName)
+
+	// Old secret must be gone
+	got := &v1.Secret{}
+	getErr := trackingClient.Get(context.TODO(), types.NamespacedName{Name: oldSecretName, Namespace: argoNs}, got)
+	assert.True(t, k8errors.IsNotFound(getErr), "old secret should be deleted after cleanup")
+
+	// The patch that stripped the label must have been recorded
+	require.Len(t, patchedSecrets, 1, "expected exactly one patch (de-label) before deletion")
+	assert.Equal(t, oldSecretName, patchedSecrets[0].name)
+	_, hasClusterTypeLabel := patchedSecrets[0].labels["argocd.argoproj.io/secret-type"]
+	assert.False(t, hasClusterTypeLabel,
+		"argocd.argoproj.io/secret-type label must be absent in the patch sent before deletion")
+}
+
+// patchTrackingClient wraps a client.Client and invokes onPatch for every Patch call.
+type patchTrackingClient struct {
+	client.Client
+	onPatch func(obj client.Object)
+}
+
+func (c *patchTrackingClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if c.onPatch != nil {
+		c.onPatch(obj)
+	}
+	return c.Client.Patch(ctx, obj, patch, opts...)
+}
+
 func TestTruncateLabelValue(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/utils/cluster.go
+++ b/pkg/utils/cluster.go
@@ -15,6 +15,7 @@
 package utils
 
 import (
+	"crypto/subtle"
 	"encoding/base64"
 	"errors"
 	"io/ioutil"
@@ -167,11 +168,22 @@ var ManagedServiceAccountPredicateFunc = predicate.TypedFuncs[*authv1beta1.Manag
 		oldmsa := e.ObjectOld
 		newmsa := e.ObjectNew
 
-		secretUpdated := !reflect.DeepEqual(oldmsa.Status.TokenSecretRef, newmsa.Status.TokenSecretRef)
+		// Fire on TokenSecretRef changes (new secret name or LastRefreshTimestamp bump).
+		// LastRefreshTimestamp is updated by the addon agent whenever the token is refreshed
+		// in-place (same secret name, new token payload), so this catches the common rotation
+		// case where only the token data changes.
+		secretRefUpdated := !reflect.DeepEqual(oldmsa.Status.TokenSecretRef, newmsa.Status.TokenSecretRef)
 
-		klog.Infof("Managed service account (%v/%v) tokenSecrefRef updated: %v", newmsa.GetNamespace(), newmsa.GetName(), secretUpdated)
+		// Also fire when ExpirationTimestamp changes, which signals that the managed-serviceaccount
+		// controller has issued a new token and updated the expiry window.
+		expirationUpdated := !reflect.DeepEqual(oldmsa.Status.ExpirationTimestamp, newmsa.Status.ExpirationTimestamp)
 
-		return secretUpdated
+		triggered := secretRefUpdated || expirationUpdated
+
+		klog.Infof("Managed service account (%v/%v) status changed: tokenSecretRef=%v expirationTimestamp=%v -> reconcile=%v",
+			newmsa.GetNamespace(), newmsa.GetName(), secretRefUpdated, expirationUpdated, triggered)
+
+		return triggered
 	},
 	CreateFunc: func(e event.TypedCreateEvent[*authv1beta1.ManagedServiceAccount]) bool {
 		msa := e.Object
@@ -194,6 +206,33 @@ var ManagedServiceAccountPredicateFunc = predicate.TypedFuncs[*authv1beta1.Manag
 		klog.Infof("Managed service account doesn't have tokenSecrefRef: %v/%v", e.Object.GetNamespace(), e.Object.GetName())
 
 		return false
+	},
+}
+
+// MSATokenSecretPredicateFunc fires when the token payload of an MSA token secret changes.
+// MSA token secrets carry the label
+// "authentication.open-cluster-management.io/is-managed-serviceaccount=true" and live in
+// managed-cluster namespaces on the hub. The managed-serviceaccount addon agent refreshes
+// these secrets in-place (same name, new token bytes), so a TokenSecretRef name change is
+// NOT triggered in that scenario. This predicate closes that gap by watching the raw token
+// bytes directly. It is used together with a secondary cache scoped to the MSA label so
+// that the controller does not watch all secrets cluster-wide.
+var MSATokenSecretPredicateFunc = predicate.TypedFuncs[*v1.Secret]{
+	UpdateFunc: func(e event.TypedUpdateEvent[*v1.Secret]) bool {
+		oldToken := e.ObjectOld.Data["token"]
+		newToken := e.ObjectNew.Data["token"]
+		if len(oldToken) == len(newToken) && subtle.ConstantTimeCompare(oldToken, newToken) == 1 {
+			return false
+		}
+		klog.Infof("MSA token secret %v/%v: token data changed, triggering reconcile",
+			e.ObjectNew.GetNamespace(), e.ObjectNew.GetName())
+		return true
+	},
+	CreateFunc: func(e event.TypedCreateEvent[*v1.Secret]) bool {
+		return len(e.Object.Data["token"]) > 0
+	},
+	DeleteFunc: func(e event.TypedDeleteEvent[*v1.Secret]) bool {
+		return true
 	},
 }
 


### PR DESCRIPTION
…oken gets rotated

https://redhat.atlassian.net/browse/ACM-37277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of GitOps cluster secret handling by watching the correct Argo CD cluster secret label.
  * Reduced the chance of missed credential refreshes by rechecking cluster state on a regular interval.
  * Made stale cluster secret cleanup safer by removing the cluster label before deletion, helping avoid temporary gaps that could disrupt application sync history.
  * Improved account/token update detection so refreshes are picked up more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->