### PR TITLE
WIP - Fix: do not force destinationBasedMapping for autonomous mode agents

### DIFF
--- a/pkg/controller/gitopscluster/agent_version_heal.go
+++ b/pkg/controller/gitopscluster/agent_version_heal.go
@@ -368,8 +368,19 @@ func (r *ReconcileGitOpsCluster) reconcileArgoCDPolicyAgentSpec(instance *gitops
 					needsUpdate = true
 				}
 
+				// destinationBasedMapping is not supported when the agent runs in autonomous
+				// mode (the argocd-agent binary fails to start with it enabled), so only force
+				// it on for managed-mode agents. For autonomous mode, actively ensure it stays
+				// disabled so previously-broken policies self-heal instead of crash-looping.
 				dbm := ensureNestedMap(agent, "destinationBasedMapping")
-				if dbm["enabled"] != true {
+				if mode == "autonomous" {
+					if dbm["enabled"] != false {
+						dbm["enabled"] = false
+						klog.Infof("Patching Policy %s/%s policy-templates[%d]: disabling argoCDAgent.agent.destinationBasedMapping (unsupported in autonomous mode)",
+							instance.Namespace, policyName, ptIdx)
+						needsUpdate = true
+					}
+				} else if dbm["enabled"] != true {
 					dbm["enabled"] = true
 					klog.Infof("Patching Policy %s/%s policy-templates[%d]: enabling argoCDAgent.agent.destinationBasedMapping",
 						instance.Namespace, policyName, ptIdx)

--- a/pkg/controller/gitopscluster/agent_version_heal_test.go
+++ b/pkg/controller/gitopscluster/agent_version_heal_test.go
@@ -254,7 +254,7 @@ func TestReconcileArgoCDPolicyAgentSpec_FieldLogic(t *testing.T) {
 		}
 
 		assert.True(t, needsUpdate, "should patch away a stale destinationBasedMapping=true left over from managed mode")
-		assert.Equal(t, false, dbm["enabled"])
+		assert.Equal(t, false, dbm["enabled"], "destinationBasedMapping.enabled should be forced to false to prevent the agent from crash-looping in autonomous mode")
 	})
 
 	t.Run("destinationBasedMapping already false for autonomous mode needs no update", func(t *testing.T) {

--- a/pkg/controller/gitopscluster/agent_version_heal_test.go
+++ b/pkg/controller/gitopscluster/agent_version_heal_test.go
@@ -219,7 +219,7 @@ func TestReconcileArgoCDPolicyAgentSpec_NilDynamicClient(t *testing.T) {
 func TestReconcileArgoCDPolicyAgentSpec_FieldLogic(t *testing.T) {
 	// Test that ensureNestedMap + field comparison logic works correctly
 	// for all the fields that reconcileArgoCDPolicyAgentSpec manages.
-	t.Run("destinationBasedMapping defaults to absent and must be set", func(t *testing.T) {
+	t.Run("destinationBasedMapping defaults to absent and must be set for managed mode", func(t *testing.T) {
 		agent := map[string]interface{}{}
 		dbm := ensureNestedMap(agent, "destinationBasedMapping")
 		assert.NotNil(t, dbm)
@@ -228,6 +228,56 @@ func TestReconcileArgoCDPolicyAgentSpec_FieldLogic(t *testing.T) {
 		assert.NotEqual(t, true, dbm["enabled"], "newly created map should not have enabled=true yet")
 		dbm["enabled"] = true
 		assert.Equal(t, true, dbm["enabled"])
+	})
+
+	t.Run("destinationBasedMapping must be forced off for autonomous mode", func(t *testing.T) {
+		// destinationBasedMapping is unsupported by the argocd-agent binary when
+		// running in autonomous mode; reconcileArgoCDPolicyAgentSpec must not enable
+		// it, and must actively disable it if a previous (buggy) reconcile turned it on.
+		agent := map[string]interface{}{
+			"destinationBasedMapping": map[string]interface{}{
+				"enabled": true,
+			},
+		}
+		mode := "autonomous"
+
+		dbm := ensureNestedMap(agent, "destinationBasedMapping")
+		needsUpdate := false
+		if mode == "autonomous" {
+			if dbm["enabled"] != false {
+				dbm["enabled"] = false
+				needsUpdate = true
+			}
+		} else if dbm["enabled"] != true {
+			dbm["enabled"] = true
+			needsUpdate = true
+		}
+
+		assert.True(t, needsUpdate, "should patch away a stale destinationBasedMapping=true left over from managed mode")
+		assert.Equal(t, false, dbm["enabled"])
+	})
+
+	t.Run("destinationBasedMapping already false for autonomous mode needs no update", func(t *testing.T) {
+		agent := map[string]interface{}{
+			"destinationBasedMapping": map[string]interface{}{
+				"enabled": false,
+			},
+		}
+		mode := "autonomous"
+
+		dbm := ensureNestedMap(agent, "destinationBasedMapping")
+		needsUpdate := false
+		if mode == "autonomous" {
+			if dbm["enabled"] != false {
+				dbm["enabled"] = false
+				needsUpdate = true
+			}
+		} else if dbm["enabled"] != true {
+			dbm["enabled"] = true
+			needsUpdate = true
+		}
+
+		assert.False(t, needsUpdate, "no update should be needed when destinationBasedMapping is already correct for autonomous mode")
 	})
 
 	t.Run("client fields absent on legacy policy template", func(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes #561.

`reconcileArgoCDPolicyAgentSpec` in `pkg/controller/gitopscluster/agent_version_heal.go` unconditionally patched `argoCDAgent.agent.destinationBasedMapping.enabled=true` into the generated ArgoCD `Policy`, even when the `GitOpsCluster` is configured with `mode: autonomous`. The `argocd-agent` binary refuses to start in that mode with this field enabled:

```
[FATAL]: Could not create a new agent instance: destination-based mapping is not supported for autonomous agents
```

Because the generated Policy is enforced (`remediationAction: enforce`), this caused a permanent crash loop with no supported way to recover — any manual fix to the `ArgoCD` CR, or to the Policy itself, was reverted on the next heal cycle.

## Change
Gate the `destinationBasedMapping` patch on `mode != "autonomous"`, and actively drive `destinationBasedMapping.enabled` to `false` when `mode == "autonomous"` so previously-broken policies self-heal, mirroring the existing per-mode handling already used for `client.mode` a few lines above in the same function.

## Testing
- Added unit test coverage for both the autonomous (force-disable) and managed (force-enable) cases, plus a no-op case when the field is already correct for autonomous mode.
- `go build ./pkg/controller/gitopscluster/...` — clean
- `go vet ./pkg/controller/gitopscluster/...` — clean
- `go test ./pkg/controller/gitopscluster/...` — all tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented destination-based mapping from being enabled in autonomous agent mode, avoiding related failures.
  * Ensured stale enabled settings are corrected automatically.
  * Preserved existing behavior for non-autonomous modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->