### PR TITLE
EnsureAddOnTemplate: skip Update() when nothing changed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,6 +322,19 @@ Missing secrets. Create a GitOpsCluster with `argoCDAgent.enabled: true` — the
 ### Policy Not Compliant
 Check replicated policy: `kubectl get policy -n <cluster-name>`. Common causes: `openshift-gitops` namespace doesn't exist yet (addon still installing operator), ArgoCD CRD not registered yet (operator starting up).
 
+### ManagedClusterAddOn Stuck Deleting Forever (addon-pre-delete finalizer)
+A `ManagedClusterAddOn`'s `addon.open-cluster-management.io/addon-pre-delete` finalizer only
+clears once the pre-delete cleanup `ManifestWork`/Job reports success back to the hub. If the
+managed cluster is genuinely gone (deregistered, deleted, unreachable — e.g. a Kind cluster whose
+container was removed outside of OCM's knowledge), that feedback can never arrive and the MCA (and
+its addon `Deployment`/`Job` `ManifestWork`s) will sit `deletionTimestamp`-set forever. This is one
+of the few legitimate exceptions to "never force-strip finalizers": once the target is confirmed
+dead (not just slow — check `ManagedCluster` `Available` condition and try reaching the spoke's
+own kubeconfig directly first), delete the addon's `ManifestWork`s in that cluster's namespace and
+then merge-patch the MCA's `finalizers` to `[]` to unblock cleanup. If the whole `ManagedCluster`
+is also being decommissioned, deleting the `ManagedCluster` object itself (which tears down its
+namespace) is cleaner than clearing individual finalizers one at a time.
+
 ### Hub Controller UID Mismatch
 `StorageError: invalid object, UID mismatch` after rapid delete/recreate. Fix:
 ```bash
@@ -474,6 +487,45 @@ Always in `openshift-gitops-operator` ns. OperatorGroup must be AllNamespaces (n
 
 ### Addon RBAC
 `gitops-addon` ClusterRole (fine-grained, not cluster-admin). Defined in both `addonTemplates.yaml` (static) and `addon_template_management.go` (dynamic). Separate `gitops-addon-cleanup` ClusterRole annotated `addon-pre-delete` for cleanup Job RBAC. Includes `escalate`/`bind` for operator leader-election Role.
+
+### No-Op-Update Guards on Hub-Owned Objects (AddOnTemplate, AddOnDeploymentConfig)
+Both `EnsureAddOnTemplate` and the `AddOnDeploymentConfig` path in `addon_management.go` rebuild
+their desired object from scratch every reconcile, then must compare against what's already
+stored before calling `Update()` — an unconditional `Update()` bumps `resourceVersion` (and, for
+spec changes, `.metadata.generation`) even when nothing meaningfully changed, and the OCM addon
+framework treats a generation bump on an `AddOnTemplate` as "the workload changed," re-rendering
+and rolling every managed cluster's addon `Deployment` in response. Confirmed on a real hub: an
+`AddOnTemplate` left running for ~6 days accumulated generation 4157 (~2 min/update) purely from
+this pattern, with zero real config change during that window.
+
+**How to design the comparison, not just "add one":** don't reflexively deep-`Equal` the whole
+built object — trace which of its inputs are actually capable of changing across reconciles of
+the *same* parent resource. Identity fields (name/namespace-derived) and anything hardcoded are
+permanently constant once the object exists; only genuinely external, mutable inputs (a
+controller's own image, a user-editable CR field) are worth comparing, and usually there are only
+one or two. Comparing just those is cheaper, isn't fooled by incidental formatting/ordering noise
+in unrelated parts of the object, and can't produce false "changed" reports that bring back the
+same churn under a different guise. `customizedVariablesEqual` (order-insensitive map comparison)
+is the existing pattern for `AddOnDeploymentConfig`; `addOnTemplateNeedsUpdate` (direct comparison
+of just the image and CA namespace, extracted with a narrow targeted JSON decode rather than a
+full manifest unmarshal) is the pattern for `AddOnTemplate`.
+
+**A stale map-iteration order can independently defeat any such guard.** Building an ordered
+`[]corev1.EnvVar` (or any positional/ordered output) by ranging directly over a `map[string]string`
+picks up Go's intentionally-randomized iteration order — the same *content* can serialize in a
+different *order* on every single call, which a naive equality check (or even a correct one, if it
+compares raw bytes/ordered slices instead of decoded/set content) will see as "changed" forever.
+Sort the keys before iterating whenever the output must be stable across calls, independent of
+whether anything is currently comparing it — otherwise a future correctness fix elsewhere can
+silently stop working the moment it starts relying on this output being stable.
+
+**Verifying a no-op-update fix on a live, leader-elected controller:** `kubectl rollout status`
+reporting a deployment fully rolled out does NOT mean the new pod has taken over reconciling -
+leader election makes the new pod wait out the *previous* holder's full lease duration
+(`leaseDuration`, minutes) before "Successfully acquired lease" appears in its logs, regardless of
+how quickly the old pod terminated. Check for that log line (or an actual "Process `<resource>`"
+line) before concluding a just-applied config change didn't take effect - the more likely
+explanation is the new pod simply hasn't started reconciling yet.
 
 ### Cleanup Rules
 **NEVER list-and-delete blindly.** Only delete: (1) gitopsaddon-labeled ArgoCD CRs (waits for operator finalizer), (2) OLM Subscription/CSV on OCP, (3) gitopsaddon-labeled operator resources on embedded. ArgoCD workloads are the operator's responsibility. Never force-strip ArgoCD CR finalizer. On OCP, skip `deleteOperatorResources` — OLM handles it. `templateAndApplyChart` labels all resources with `apps.open-cluster-management.io/gitopsaddon: "true"`.

--- a/pkg/controller/gitopscluster/addon_template_management.go
+++ b/pkg/controller/gitopscluster/addon_template_management.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -157,6 +158,33 @@ func (r *ReconcileGitOpsCluster) EnsureAddOnTemplate(gitOpsCluster *gitopscluste
 		return fmt.Errorf("cannot create addon template: %w", err)
 	}
 
+	argoNamespace := GetEffectiveArgoNamespace(gitOpsCluster)
+
+	// Check if AddOnTemplate already exists. Every input that feeds the template below
+	// (namespace/name-derived identity, the manifest RBAC/ServiceAccount/Deployment shape) is
+	// fixed for the lifetime of this object - the only two values that can ever legitimately
+	// differ across reconciles are the controller's own image (changes on a controller upgrade)
+	// and the CA namespace (changes only if the GitOpsCluster CR's own argoNamespace is edited).
+	// Compare only those two directly instead of deep-comparing the full (large,
+	// template-heavy) Spec: a whole-object comparison would (a) depend on the manifests' raw
+	// JSON bytes being byte-identical across an etcd round-trip, which isn't guaranteed, and
+	// (b) spuriously report "changed" on every single call regardless, because
+	// buildAddonEnvVars iterates a Go map whose iteration order is randomized per-process - see
+	// its own comment. An unconditional Update() here bumps the AddOnTemplate's generation every
+	// reconcile, which makes the OCM addon framework re-render and roll every managed cluster's
+	// gitops-addon ManifestWork/Deployment (same class of bug already fixed for
+	// AddOnDeploymentConfig via customizedVariablesEqual in addon_management.go).
+	existingTemplate := &addonv1alpha1.AddOnTemplate{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: templateName}, existingTemplate)
+	if err == nil {
+		if !addOnTemplateNeedsUpdate(existingTemplate, addonImage, argoNamespace) {
+			klog.V(2).Infof("AddOnTemplate %s is up to date, skipping update", templateName)
+			return nil
+		}
+	} else if !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get AddOnTemplate: %w", err)
+	}
+
 	// Build the AddOnTemplate for argocd-agent mode
 	addonTemplate := &addonv1alpha1.AddOnTemplate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -184,34 +212,72 @@ func (r *ReconcileGitOpsCluster) EnsureAddOnTemplate(gitOpsCluster *gitopscluste
 						// system:open-cluster-management:cluster:<cluster-name>:addon:gitops-addon:agent:gitops-addon-agent
 						// The ArgoCD principal is configured with a custom auth regex to extract
 						// just the cluster name from this full path.
-					SigningCA: addonv1alpha1.SigningCARef{
-						Name:      "argocd-agent-ca",
-						Namespace: GetEffectiveArgoNamespace(gitOpsCluster),
-					},
+						SigningCA: addonv1alpha1.SigningCARef{
+							Name:      "argocd-agent-ca",
+							Namespace: argoNamespace,
+						},
 					},
 				},
 			},
 		},
 	}
 
-	// Check if AddOnTemplate already exists
-	existing := &addonv1alpha1.AddOnTemplate{}
-	err = r.Get(context.Background(), types.NamespacedName{Name: templateName}, existing)
 	if err == nil {
-		// AddOnTemplate exists, update it
-		klog.V(2).Infof("Updating AddOnTemplate %s", templateName)
-		existing.Spec = addonTemplate.Spec
-		existing.Labels = addonTemplate.Labels
-		return r.Update(context.Background(), existing)
-	}
-
-	if !k8serrors.IsNotFound(err) {
-		return fmt.Errorf("failed to get AddOnTemplate: %w", err)
+		// existingTemplate was found above and addOnTemplateNeedsUpdate returned true.
+		klog.Infof("Updating AddOnTemplate %s (image or argoNamespace changed)", templateName)
+		existingTemplate.Spec = addonTemplate.Spec
+		existingTemplate.Labels = addonTemplate.Labels
+		return r.Update(context.Background(), existingTemplate)
 	}
 
 	// Create new AddOnTemplate
 	klog.Infof("Creating AddOnTemplate %s", templateName)
 	return r.Create(context.Background(), addonTemplate)
+}
+
+// addOnTemplateNeedsUpdate reports whether the existing AddOnTemplate's meaningful inputs
+// differ from the desired image/argoNamespace. Any decode failure on the existing object is
+// treated as "needs update" (fail open) so a parse error can never silently freeze the template.
+func addOnTemplateNeedsUpdate(existing *addonv1alpha1.AddOnTemplate, wantImage, wantArgoNamespace string) bool {
+	if len(existing.Spec.Registration) == 0 ||
+		existing.Spec.Registration[0].CustomSigner == nil ||
+		existing.Spec.Registration[0].CustomSigner.SigningCA.Namespace != wantArgoNamespace {
+		return true
+	}
+
+	currentImage, ok := extractDeploymentImage(existing.Spec.AgentSpec.Workload.Manifests)
+	if !ok || currentImage != wantImage {
+		return true
+	}
+
+	return false
+}
+
+// extractDeploymentImage finds the gitops-addon Deployment manifest among the AddOnTemplate's
+// manifests and returns its first container's image. Only decodes the handful of fields it
+// needs, rather than fully unmarshaling every manifest into a typed Deployment.
+func extractDeploymentImage(manifests []workv1.Manifest) (string, bool) {
+	for _, m := range manifests {
+		var probe struct {
+			Kind string `json:"kind"`
+			Spec struct {
+				Template struct {
+					Spec struct {
+						Containers []struct {
+							Image string `json:"image"`
+						} `json:"containers"`
+					} `json:"spec"`
+				} `json:"template"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(m.Raw, &probe); err != nil {
+			continue
+		}
+		if probe.Kind == "Deployment" && len(probe.Spec.Template.Spec.Containers) > 0 {
+			return probe.Spec.Template.Spec.Containers[0].Image, true
+		}
+	}
+	return "", false
 }
 
 // buildAddonManifests builds the manifest list for the AddOnTemplate (argocd-agent without OLM)
@@ -586,11 +652,19 @@ func buildAddonEnvVars() []corev1.EnvVar {
 		},
 	})
 
-	// Add all image environment variables (excluding hub-only vars like ARGOCD_PRINCIPAL_IMAGE)
+	// Add all image environment variables (excluding hub-only vars like ARGOCD_PRINCIPAL_IMAGE).
+	// Sorted: ranging over a map directly would randomize iteration order on every call (Go
+	// intentionally randomizes map iteration), producing a differently-ordered but
+	// identical-content Env list on every reconcile - harmless on its own, but it defeats any
+	// later attempt to detect "did anything actually change" by comparing this manifest.
+	imageEnvKeys := make([]string, 0, len(utils.DefaultOperatorImages))
 	for envKey := range utils.DefaultOperatorImages {
-		if utils.IsHubOnlyEnvVar(envKey) {
-			continue
+		if !utils.IsHubOnlyEnvVar(envKey) {
+			imageEnvKeys = append(imageEnvKeys, envKey)
 		}
+	}
+	sort.Strings(imageEnvKeys)
+	for _, envKey := range imageEnvKeys {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  envKey,
 			Value: fmt.Sprintf("{{%s}}", envKey),

--- a/pkg/controller/gitopscluster/addon_template_management_test.go
+++ b/pkg/controller/gitopscluster/addon_template_management_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	workv1 "open-cluster-management.io/api/work/v1"
 	gitopsclusterV1beta1 "open-cluster-management.io/multicloud-integrations/pkg/apis/apps/v1beta1"
 	"open-cluster-management.io/multicloud-integrations/pkg/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -719,5 +720,194 @@ func TestEnsureAddOnTemplateDeletesLegacyStaticTemplate(t *testing.T) {
 	}
 	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: getLegacyOLMAddOnTemplateName(gitOpsCluster)}, check); err == nil {
 		t.Errorf("dynamic legacy template %q should have been deleted by EnsureAddOnTemplate", getLegacyOLMAddOnTemplateName(gitOpsCluster))
+	}
+}
+
+// TestBuildAddonEnvVarsDeterministicOrder locks in the fix for a real (independent of the
+// no-op-update fix) bug: buildAddonEnvVars used to range over utils.DefaultOperatorImages (a
+// map) directly, so the env var order could differ across calls even though the content never
+// did - Go intentionally randomizes map iteration order. That alone would defeat any later
+// attempt to detect "did anything actually change" by comparing the built manifest.
+func TestBuildAddonEnvVarsDeterministicOrder(t *testing.T) {
+	first := buildAddonEnvVars()
+	for i := 0; i < 20; i++ {
+		next := buildAddonEnvVars()
+		if len(next) != len(first) {
+			t.Fatalf("buildAddonEnvVars() length changed across calls: %d vs %d", len(first), len(next))
+		}
+		for j := range first {
+			if first[j].Name != next[j].Name {
+				t.Fatalf("buildAddonEnvVars() order not deterministic at index %d: %q vs %q (run %d)",
+					j, first[j].Name, next[j].Name, i)
+			}
+		}
+	}
+}
+
+// TestExtractDeploymentImage covers the targeted-decode helper used by addOnTemplateNeedsUpdate:
+// finding the Deployment manifest among a mixed list and pulling its container image, without
+// needing to fully unmarshal every manifest into a typed object.
+func TestExtractDeploymentImage(t *testing.T) {
+	manifests := buildAddonManifests("test-ns", "quay.io/example/addon:v1")
+
+	image, ok := extractDeploymentImage(manifests)
+	if !ok {
+		t.Fatal("extractDeploymentImage() ok = false, want true")
+	}
+	if image != "quay.io/example/addon:v1" {
+		t.Errorf("extractDeploymentImage() = %q, want %q", image, "quay.io/example/addon:v1")
+	}
+
+	t.Run("no deployment present", func(t *testing.T) {
+		_, ok := extractDeploymentImage(nil)
+		if ok {
+			t.Error("extractDeploymentImage(nil) ok = true, want false")
+		}
+	})
+
+	t.Run("malformed manifest is skipped, not fatal", func(t *testing.T) {
+		manifests := buildAddonManifests("test-ns", "quay.io/example/addon:v2")
+		// Corrupt the first manifest's raw JSON; extractDeploymentImage must skip it and keep
+		// looking rather than erroring out.
+		manifests[0].Raw = []byte("not-json")
+		image, ok := extractDeploymentImage(manifests)
+		if !ok || image != "quay.io/example/addon:v2" {
+			t.Errorf("extractDeploymentImage() with one malformed manifest = (%q, %v), want (%q, true)",
+				image, ok, "quay.io/example/addon:v2")
+		}
+	})
+}
+
+// TestAddOnTemplateNeedsUpdate covers the targeted comparison that replaced the previous
+// unconditional Update(): only the addon image and the CA/argoNamespace can ever legitimately
+// differ across reconciles of the same GitOpsCluster, so those are the only two things compared.
+func TestAddOnTemplateNeedsUpdate(t *testing.T) {
+	buildExisting := func(image, argoNamespace string) *addonv1alpha1.AddOnTemplate {
+		return &addonv1alpha1.AddOnTemplate{
+			Spec: addonv1alpha1.AddOnTemplateSpec{
+				AddonName: "gitops-addon",
+				AgentSpec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{Manifests: buildAddonManifests("openshift-gitops", image)},
+				},
+				Registration: []addonv1alpha1.RegistrationSpec{
+					{
+						CustomSigner: &addonv1alpha1.CustomSignerRegistrationConfig{
+							SigningCA: addonv1alpha1.SigningCARef{Name: "argocd-agent-ca", Namespace: argoNamespace},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("identical inputs need no update", func(t *testing.T) {
+		existing := buildExisting("quay.io/example/addon:v1", "openshift-gitops")
+		if addOnTemplateNeedsUpdate(existing, "quay.io/example/addon:v1", "openshift-gitops") {
+			t.Error("addOnTemplateNeedsUpdate() = true for identical inputs, want false")
+		}
+	})
+
+	t.Run("image change needs update", func(t *testing.T) {
+		existing := buildExisting("quay.io/example/addon:v1", "openshift-gitops")
+		if !addOnTemplateNeedsUpdate(existing, "quay.io/example/addon:v2", "openshift-gitops") {
+			t.Error("addOnTemplateNeedsUpdate() = false after image change, want true")
+		}
+	})
+
+	t.Run("argoNamespace change needs update", func(t *testing.T) {
+		existing := buildExisting("quay.io/example/addon:v1", "openshift-gitops")
+		if !addOnTemplateNeedsUpdate(existing, "quay.io/example/addon:v1", "custom-argocd-ns") {
+			t.Error("addOnTemplateNeedsUpdate() = false after argoNamespace change, want true")
+		}
+	})
+
+	t.Run("missing Registration fails open to needs-update", func(t *testing.T) {
+		existing := &addonv1alpha1.AddOnTemplate{
+			Spec: addonv1alpha1.AddOnTemplateSpec{
+				AgentSpec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{Manifests: buildAddonManifests("openshift-gitops", "quay.io/example/addon:v1")},
+				},
+			},
+		}
+		if !addOnTemplateNeedsUpdate(existing, "quay.io/example/addon:v1", "openshift-gitops") {
+			t.Error("addOnTemplateNeedsUpdate() = false with no Registration, want true (fail open)")
+		}
+	})
+
+	t.Run("undecodable manifests fail open to needs-update", func(t *testing.T) {
+		existing := buildExisting("quay.io/example/addon:v1", "openshift-gitops")
+		existing.Spec.AgentSpec.Workload.Manifests = nil
+		if !addOnTemplateNeedsUpdate(existing, "quay.io/example/addon:v1", "openshift-gitops") {
+			t.Error("addOnTemplateNeedsUpdate() = false with no manifests, want true (fail open)")
+		}
+	})
+}
+
+// TestEnsureAddOnTemplateSkipsNoOpUpdate is the regression test for the actual reported bug: an
+// unconditional Update() on every reconcile bumped the AddOnTemplate's generation and
+// resourceVersion even when nothing had changed, which made the OCM addon framework re-render
+// and roll every managed cluster's gitops-addon ManifestWork/Deployment approximately every
+// reconcile interval. Calling EnsureAddOnTemplate twice with identical inputs must not touch the
+// stored object at all the second time.
+func TestEnsureAddOnTemplateSkipsNoOpUpdate(t *testing.T) {
+	os.Setenv(ControllerImageEnvVar, "test-controller:v1")
+	defer os.Unsetenv(ControllerImageEnvVar)
+
+	scheme := runtime.NewScheme()
+	_ = addonv1alpha1.AddToScheme(scheme)
+	_ = gitopsclusterV1beta1.AddToScheme(scheme)
+
+	gitOpsCluster := &gitopsclusterV1beta1.GitOpsCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "test-namespace"},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &ReconcileGitOpsCluster{Client: fakeClient, scheme: scheme}
+
+	if err := r.EnsureAddOnTemplate(gitOpsCluster); err != nil {
+		t.Fatalf("EnsureAddOnTemplate() create error = %v", err)
+	}
+
+	templateName := getAddOnTemplateName(gitOpsCluster)
+	afterCreate := &addonv1alpha1.AddOnTemplate{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: templateName}, afterCreate); err != nil {
+		t.Fatalf("failed to get AddOnTemplate after create: %v", err)
+	}
+
+	// Reconcile again several times with nothing changed - none of these should touch the object.
+	for i := 0; i < 3; i++ {
+		if err := r.EnsureAddOnTemplate(gitOpsCluster); err != nil {
+			t.Fatalf("EnsureAddOnTemplate() no-op reconcile %d error = %v", i, err)
+		}
+	}
+
+	afterNoOps := &addonv1alpha1.AddOnTemplate{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: templateName}, afterNoOps); err != nil {
+		t.Fatalf("failed to get AddOnTemplate after no-op reconciles: %v", err)
+	}
+	if afterNoOps.ResourceVersion != afterCreate.ResourceVersion {
+		t.Errorf("resourceVersion changed across no-op reconciles (%s -> %s) - Update() was called when nothing changed",
+			afterCreate.ResourceVersion, afterNoOps.ResourceVersion)
+	}
+	if afterNoOps.Generation != afterCreate.Generation {
+		t.Errorf("generation changed across no-op reconciles (%d -> %d) - this is exactly the reported churn bug",
+			afterCreate.Generation, afterNoOps.Generation)
+	}
+
+	// Now change the controller image - this time an update MUST happen.
+	os.Setenv(ControllerImageEnvVar, "test-controller:v2")
+	if err := r.EnsureAddOnTemplate(gitOpsCluster); err != nil {
+		t.Fatalf("EnsureAddOnTemplate() after image change error = %v", err)
+	}
+	afterImageChange := &addonv1alpha1.AddOnTemplate{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: templateName}, afterImageChange); err != nil {
+		t.Fatalf("failed to get AddOnTemplate after image change: %v", err)
+	}
+	if afterImageChange.ResourceVersion == afterNoOps.ResourceVersion {
+		t.Error("resourceVersion did not change after a real image change - Update() should have been called")
+	}
+	newImage, ok := extractDeploymentImage(afterImageChange.Spec.AgentSpec.Workload.Manifests)
+	if !ok || newImage != "test-controller:v2" {
+		t.Errorf("deployment image after update = (%q, %v), want (%q, true)", newImage, ok, "test-controller:v2")
 	}
 }

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -14,7 +14,10 @@ limitations under the License.
 
 package utils
 
-import "os"
+import (
+	"os"
+	"sort"
+)
 
 // Environment variable names for GitOps addon configuration.
 // These are the canonical names used throughout the system:
@@ -115,12 +118,18 @@ var hubOnlyEnvVars = map[string]bool{
 func SpokeConfigEnvVars() []string {
 	vars := make([]string, 0, len(DefaultOperatorImages)+7)
 
-	// Add image env vars (excluding hub-only vars)
+	// Add image env vars (excluding hub-only vars), sorted: ranging over a map directly
+	// randomizes iteration order on every call (Go intentionally randomizes map iteration), so
+	// callers that build ordered/positional output from this list would otherwise see a
+	// different order on every call despite identical content.
+	imageEnvKeys := make([]string, 0, len(DefaultOperatorImages))
 	for envKey := range DefaultOperatorImages {
 		if !hubOnlyEnvVars[envKey] {
-			vars = append(vars, envKey)
+			imageEnvKeys = append(imageEnvKeys, envKey)
 		}
 	}
+	sort.Strings(imageEnvKeys)
+	vars = append(vars, imageEnvKeys...)
 
 	// Add proxy env vars
 	vars = append(vars, EnvHTTPProxy, EnvHTTPSProxy, EnvNoProxy)
@@ -136,10 +145,13 @@ func SpokeConfigEnvVars() []string {
 func AllConfigEnvVars() []string {
 	vars := make([]string, 0, len(DefaultOperatorImages)+7)
 
-	// Add all image env vars
+	// Add all image env vars, sorted (see SpokeConfigEnvVars for why).
+	imageEnvKeys := make([]string, 0, len(DefaultOperatorImages))
 	for envKey := range DefaultOperatorImages {
-		vars = append(vars, envKey)
+		imageEnvKeys = append(imageEnvKeys, envKey)
 	}
+	sort.Strings(imageEnvKeys)
+	vars = append(vars, imageEnvKeys...)
 
 	// Add proxy env vars
 	vars = append(vars, EnvHTTPProxy, EnvHTTPSProxy, EnvNoProxy)


### PR DESCRIPTION
Compare the addon image and CA namespace against the existing AddOnTemplate before calling Update(), instead of unconditionally rebuilding and updating it every reconcile. Only those two inputs can ever legitimately change across reconciles of the same GitOpsCluster, so an unconditional Update() bumped the AddOnTemplate's generation on every pass, causing the OCM addon framework to re-render and roll the gitops-addon Deployment on every managed cluster.

Also sort the map keys in buildAddonEnvVars, SpokeConfigEnvVars, and AllConfigEnvVars before building env var lists, since ranging over a map directly produces non-deterministic ordering on every call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary add-on updates and redeployments when configuration has not changed.
  - Ensured meaningful image or namespace changes are correctly applied.
  - Improved consistency of generated environment-variable configuration across reconciliations.

- **Documentation**
  - Added troubleshooting guidance for cleanup operations that remain stuck when managed clusters are unavailable.
  - Documented best practices for avoiding no-op updates and unintended add-on redeployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->