### PR TITLE
Add falconizmi to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+- falconizmi
 - fxiang1
 - jnpacker
 - mikeshng


### PR DESCRIPTION
Add falconizmi to OWNERS for CVE remediation reviews.

Ref: ACM-38062

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project approval ownership configuration to include an additional approver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->