### PR TITLE
Add ConfigMap-driven kill switch for the basic pull model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Then install governance addons (`governance-policy-framework` + `config-policy-c
 ## Repository Overview
 
 Every binary below is built from the same image (`quay.io/stolostron/multicloud-integrations`),
-but shipped as **two separate Deployments** on the hub — don't assume "the controller" means only
+but shipped as **three separate Deployments** on the hub — don't assume "the controller" means only
 one of them:
 
 1. **gitopscluster** — Hub-side controller in the `multicluster-operators-application` deployment.
@@ -583,14 +583,25 @@ replacing the object it manages.
      achieved, nothing more to do.
    - `{"server":"https://kubernetes.default.svc", ...}` (the old pull-model value) — not yet taken
      over. Replace the stale spoke copy: remove `syncPolicy.automated` on the **spoke's** copy
-     first (so the delete below doesn't prune the real resources), strip its `finalizers` to `[]`
-     and delete it directly on the spoke, confirm the real workload's pod `uid` is unchanged, then
-     nudge a fresh dispatch from the hub (any harmless annotation touch — the first create attempt
-     right after the stale copy disappears can race and silently fail once). Recheck
-     `spec.destination` on the spoke again after ~30s; it should now be `name`-based. Confirmed
-     live for both `ApplicationSet`-owned and standalone apps: the workload's pod `uid` never
-     changes across this replacement, because `automated` (and its `prune: true`) was removed from
-     the spoke copy before it was deleted.
+     first (so the delete below doesn't prune the real resources), then remove *only*
+     `resources-finalizer.argocd.argoproj.io` from its `finalizers` — preserve any other,
+     unrelated finalizer the object might carry rather than clearing the whole list — and
+     **read `.metadata.finalizers` back** before deleting — the `ApplicationSet` controller (or
+     ArgoCD's own defaulting) can silently re-add `resources-finalizer.argocd.argoproj.io` moments
+     later, the same behavior documented in "Designs that were rejected" below. If the read-back
+     is non-empty, stop and do not delete — automated is off, so there is no destructive cascade
+     in that scenario, but a delete against a re-added finalizer just times out. `kubectl` has no
+     direct delete-precondition flag, so as the closest practical equivalent, also capture
+     `.metadata.resourceVersion` from that same read-back and re-check it immediately before
+     deleting — if it changed in that window (e.g. a finalizer got re-added right after the clean
+     read-back), stop instead of deleting an object no longer confirmed clean. Only once both
+     checks pass, delete it directly on the spoke, confirm the real workload's pod `uid` is
+     unchanged, then nudge a fresh dispatch from the hub (any harmless annotation touch — the
+     first create attempt right after the stale copy disappears can race and silently fail once).
+     Recheck `spec.destination` on the spoke again after ~30s; it should now be `name`-based.
+     Confirmed live for both `ApplicationSet`-owned and standalone apps: the workload's pod `uid`
+     never changes across this replacement, because `automated` (and its `prune: true`) was removed
+     from the spoke copy before it was deleted.
 
 That's the whole migration. **No new `Application`, no new `ApplicationSet`, nothing to detach or
 delete afterward** — for the `ApplicationSet`-owned case, the same `ApplicationSet` that generated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,11 +56,29 @@ Then install governance addons (`governance-policy-framework` + `config-policy-c
 
 ## Repository Overview
 
-Two components from the same image (`quay.io/stolostron/multicloud-integrations`):
+Every binary below is built from the same image (`quay.io/stolostron/multicloud-integrations`),
+but shipped as **two separate Deployments** on the hub — don't assume "the controller" means only
+one of them:
 
-1. **gitopscluster** — Hub-side controller in `multicluster-operators-application` deployment. Reconciles `GitOpsCluster` CRs, creates Policies, MCAs, ADCs, AddOnTemplates, cluster secrets, TLS certs, and handles agent version drift healing.
+1. **gitopscluster** — Hub-side controller in the `multicluster-operators-application` deployment.
+   Reconciles `GitOpsCluster` CRs, creates Policies, MCAs, ADCs, AddOnTemplates, cluster secrets,
+   TLS certs, and handles agent version drift healing. This is the argocd-agent (principal/agent)
+   integration — see "Agent Modes" and "Hybrid Mode" below.
 
-2. **gitopsaddon** — Addon agent on each managed cluster. Installs OpenShift GitOps operator (OLM on OCP, embedded Helm chart on non-OCP), creates ArgoCD CR, manages image pull secrets, patches ServiceAccounts. Deployed by OCM addon framework.
+2. **gitopsaddon** — Addon agent on each managed cluster. Installs OpenShift GitOps operator (OLM
+   on OCP, embedded Helm chart on non-OCP), creates ArgoCD CR, manages image pull secrets, patches
+   ServiceAccounts, and optionally deploys the argocd-agent. Deployed by the OCM addon framework —
+   runs regardless of which integration model (agent or basic pull model) is in use, since both
+   need an ArgoCD instance actually installed on the spoke.
+
+3. **gitopssyncresc / multiclusterstatusaggregation / propagation** — the older, still-shipping
+   **basic pull model** integration (in the `multicluster-integrations` deployment on the hub, a
+   *third*, separate Deployment from the two above). Predates argocd-agent, has no dedicated spoke
+   agent process, and reuses the standard OCM klusterlet work-agent (`ManifestWork`) that every
+   managed cluster already has. See "Basic Pull Model" under Architecture, and "Basic Pull Model
+   Setup — Full YAML" below, for the full picture. `maestropropagation`/`maestroaggregation` are an
+   opt-in, Maestro-backed alternative to this same model for very large scale (not deployed by
+   default).
 
 ## Common Commands
 
@@ -249,6 +267,467 @@ spec:
 EOF
 ```
 
+## Basic Pull Model Setup — Full YAML
+
+The basic pull model needs no agent, no principal, no certs — just a `GitOpsCluster` with
+`gitopsAddon.enabled: true` and **no `argoCDAgent` block at all**, so the addon installs a plain
+(non-agent) ArgoCD instance on the spoke, plus an `ApplicationSet` (or a single `Application`)
+carrying the pull label/annotation. **OCP-only**: this integration is only supported for OCP
+managed clusters (OLM-installed operator) — it is not validated or supported on non-OCP (embedded
+Helm chart) spokes.
+
+```bash
+# 1. Placement selecting only the target (OCP) managed cluster(s) — reuse the same
+#    ManagedClusterSetBinding/AppProject setup as agent mode (see "Agent Mode Setup" above).
+kubectl apply -f - <<'EOF'
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: pull-model-placement
+  namespace: openshift-gitops
+spec:
+  clusterSets: [global]
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions:
+        - key: name
+          operator: In
+          values: [<ocp-managed-cluster-name>]
+EOF
+
+# 2. GitOpsCluster with gitopsAddon enabled and argoCDAgent OMITTED (not disabled — omitted).
+#    This forces createBlankClusterSecrets=true internally and installs a plain, non-agent
+#    ArgoCD via the static "gitops-addon" AddOnTemplate + OLM subscription.
+kubectl apply -f - <<'EOF'
+apiVersion: apps.open-cluster-management.io/v1beta1
+kind: GitOpsCluster
+metadata:
+  name: pull-model-gitops
+  namespace: openshift-gitops
+spec:
+  argoServer:
+    cluster: local-cluster
+    argoNamespace: openshift-gitops
+  placementRef:
+    kind: Placement
+    apiVersion: cluster.open-cluster-management.io/v1beta1
+    name: pull-model-placement
+  gitopsAddon:
+    enabled: true
+EOF
+
+# 3. Wait for the spoke's ArgoCD (application-controller, redis, repo-server — "server" is
+#    disabled by default for both agent and pull-model spokes, this is expected, see Architecture).
+#    Then create an ApplicationSet whose template carries the pull label/annotation:
+kubectl apply -f - <<'EOF'
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: pull-model-guestbook-appset
+  namespace: openshift-gitops
+spec:
+  generators:
+  - clusterDecisionResource:
+      configMapRef: acm-placement
+      labelSelector:
+        matchLabels:
+          cluster.open-cluster-management.io/placement: pull-model-placement
+      requeueAfterSeconds: 30
+  template:
+    metadata:
+      name: '{{name}}-guestbook'
+      namespace: openshift-gitops
+      labels:
+        apps.open-cluster-management.io/pull-to-ocm-managed-cluster: 'true'
+      annotations:
+        # Required whenever the hub's own app-controller is enabled (hybrid mode) and the
+        # template's destination.server is the in-cluster address — otherwise the hub tries to
+        # reconcile this placeholder Application locally in ADDITION to it being propagated.
+        argocd.argoproj.io/skip-reconcile: 'true'
+        apps.open-cluster-management.io/ocm-managed-cluster: '{{name}}'
+        apps.open-cluster-management.io/ocm-managed-cluster-app-namespace: openshift-gitops
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/argoproj/argocd-example-apps.git
+        targetRevision: HEAD
+        path: guestbook
+      destination:
+        server: https://kubernetes.default.svc   # rewritten to the spoke's in-cluster server on delivery
+        namespace: guestbook
+      syncPolicy:
+        automated: {prune: true, selfHeal: true}
+        syncOptions: [CreateNamespace=true]
+EOF
+
+# 4. Verify (see "Basic Pull Model" under Architecture for what each layer means):
+kubectl get applications.argoproj.io -n openshift-gitops                     # hub placeholder — always specify the group, see Troubleshooting
+kubectl get manifestwork -n <ocp-managed-cluster-name> | grep guestbook      # delivery vehicle
+kubectl get multiclusterapplicationsetreports -n openshift-gitops           # aggregated status back on the hub
+# on the spoke itself:
+kubectl get applications.argoproj.io -n openshift-gitops                    # propagated copy, should be Synced
+kubectl get pods -n guestbook
+```
+
+Confirmed end-to-end on a real OCP-managed cluster: the `ApplicationSet` generated the hub
+placeholder `Application`, the propagation controller wrapped it into a `ManifestWork`, the
+spoke's existing klusterlet work-agent delivered it with no new agent process involved, the
+spoke's ArgoCD `application-controller` reconciled it (`Synced`), and both status paths reported
+back correctly — the `ManifestWork` status-feedback path fed `multiclusterstatusaggregation`,
+which produced a `MulticlusterApplicationSetReport` with `syncStatus: Synced` and the real
+`guestbook-ui` `Deployment`/`Service` listed under `resources`, and `application_status_controller`
+separately reflected the same sync/health/operation state onto the hub's own `Application.status`
+(with a synthetic `AdditionalStatusReport` condition pointing at the report and the spoke
+Application for further detail). The demo `guestbook-ui` pod itself does not reach `Healthy` on
+OCP — this is the same pre-existing, non-pull-model-related restricted-SCC limitation already
+documented under "E2E Testing Gotchas" (non-root process binding port 80); `Synced` is the correct
+success bar for this specific demo image on OCP, not `Healthy`.
+
+## Disabling the Basic Pull Model (multicluster-integrations-config)
+
+The basic pull model can be turned off hub-wide via a ConfigMap, without deleting anything or
+disrupting real workloads. This is the first step of the migration runbook below, but it's a
+standalone feature in its own right — flip it whenever you want the basic-pull-model controllers to
+stop doing any work.
+
+- **ConfigMap name**: `multicluster-integrations-config`. **Namespace**: the same namespace the
+  `multicluster-integrations` pod itself runs in — resolved dynamically at runtime (`POD_NAMESPACE`
+  env var, falling back to reading the pod's mounted service-account namespace file), never
+  hardcoded to `open-cluster-management`. Package: `pkg/pullmodelconfig`.
+- **Self-provisioning**: if the ConfigMap doesn't exist, whichever of the three containers starts
+  first creates it with defaults (`pullModel.basic.disabled: false`) — race-safe across the sibling
+  containers in the same pod (Create, falling back to Get on `AlreadyExists`).
+- **Schema** (`data["config.yaml"]`, parsed as YAML):
+  ```yaml
+  pullModel:
+    basic:
+      disabled: true
+  ```
+  Nested under `pullModel.basic` specifically to disambiguate from argocd-agent, which is *also* a
+  pull-based model in the generic sense — this switch only ever affects the classic
+  ManifestWork-based basic pull model, never argocd-agent.
+- **Checked live, not cached at startup.** Each of the three components re-reads this ConfigMap
+  (a real `Get`, via `pullmodelconfig.LoadOrCreate`) at the point where the decision matters —
+  `propagation-controller/application`'s two reconcilers check it as the first thing inside every
+  single `Reconcile()` call, and `gitopssyncresc`/`multiclusterstatusaggregation` check it on every
+  tick of their periodic loop, not once when the process started. **This was a deliberate fix, not
+  the original design**: an earlier version cached the flag once at process startup, which left a
+  real race during a `kubectl rollout restart` — the OLD (not-yet-disabled) pod and the NEW
+  (disabled, already-swept) pod briefly run side by side (`RollingUpdate`'s default `maxSurge`), and
+  the old pod's cached-`false` reconciler could process one more in-flight event and recreate a
+  `ManifestWork` with `ServerSideApply` *after* the new pod's sweep had just set it to `ReadOnly`.
+  Reading live on every check closes this window regardless of which pod (old or new) happens to
+  process a given event, since both read the same up-to-date ConfigMap. Toggling the flag therefore
+  takes effect within one reconcile/tick — no restart needed for the guards themselves.
+- **The one-time `ManifestWork` sweep is the one exception that still needs a restart.** It only
+  runs once, at process startup in the propagation container's `main.go`, gated on the config value
+  read at that moment — so to sweep any `ManifestWork` that predates flipping the flag, you still
+  need `kubectl rollout restart deployment multicluster-integrations -n <namespace>`.
+- **What `disabled: true` actually does, at the code level**, across all three containers in the
+  `multicluster-integrations` Deployment:
+  - `propagation-controller/application`'s `ApplicationReconciler` and
+    `ApplicationStatusReconciler` both return `ctrl.Result{}, nil` as soon as a live config check
+    says disabled — for every event, not just filtered out at the watch/predicate level. No
+    `ManifestWork` is created, updated, or deleted by this component while disabled.
+  - `gitopssyncresc`'s periodic loop (`Start()`'s `wait.Until` body) skips `syncResources()` for any
+    tick where the live check says disabled — no ACM Search API polling that tick.
+  - `multiclusterstatusaggregation`'s periodic loop skips `houseKeeping()` the same way — no
+    `MulticlusterApplicationSetReport` generation/cleanup that tick.
+  - Once, at process startup (in the propagation container's `main.go`, before the reconcilers are
+    registered), `application.SweepManifestWorksToReadOnly` lists every `ManifestWork`
+    cluster-wide, content-matches the pull-model-owned ones (has the hub-application-name
+    annotation, and carries either the ApplicationSet-owned or standalone-pull label), and — for
+    each one's `applications`-resource `manifestConfigs` entry specifically, never by positional
+    index — sets `updateStrategy: ReadOnly` if it isn't already. This is what stops the spoke's
+    klusterlet work-agent from continuing to enforce already-delivered Application specs, without
+    deleting any ManifestWork. Idempotent: a re-run (e.g. next pod restart) finds nothing left to
+    do and is a fast no-op.
+  - None of this imports or touches `pkg/controller/gitopscluster` — verified zero coupling in
+    either direction. Disabling the basic pull model cannot affect argocd-agent.
+- **This is a hub-wide switch**, not per-app or per-cluster: it affects every basic-pull-model app
+  across every managed cluster simultaneously. There is no code path to disable it for one app or
+  one cluster only.
+- **Re-enabling** (`disabled: false` + restart) resumes normal reconciliation, but does **not**
+  automatically revert any `ManifestWork` the sweep already set to `ReadOnly` — there is no
+  "undo" sweep. If you want a specific app's `ManifestWork` back under active enforcement, patch its
+  `updateStrategy` back explicitly.
+- **RBAC**: no changes needed — `multicloud-integrations-role` already grants full CRUD on
+  `configmaps` and `manifestworks`/`manifestworks/status` cluster-wide (confirmed in
+  `deploy/controller/role.yaml`).
+
+## Migrating an App from Basic Pull Model to argocd-agent
+
+A step-by-step operator runbook with copy-pasteable commands lives in
+`docs/basic-pull-to-argocd-agent-migration.md`. This works whether the pull model was set up via
+`gitopsAddon.enabled: true` or via `GitOpsCluster.spec.createBlankClusterSecrets: true` directly —
+the latter being how the pull model predates and can exist entirely independently of the
+addon/agent machinery (see "Basic Pull Model" under Architecture).
+
+**Goal**: argocd-agent takes over the **same** Application object — same name, same UID, no new
+`Application` or `ApplicationSet` ever created — with zero pod restart/recreation, and without the
+old pull-model controllers (`multicluster-integrations`'s propagation controller) continuing to
+touch it afterward. Two earlier, more roundabout designs were tried and rejected; see "Designs
+that were rejected" below for why creating a second Application (even under a different name) is
+unnecessary and worse than this one. Getting genuine agent management (not just a hub `Application`
+that merely *looks* migrated) additionally requires step 5 below — see it for why.
+
+**Not every pull-model app has an `ApplicationSet` owner.** The propagation controller only
+requires the pull label + `ocm-managed-cluster*`/`skip-reconcile` annotations on the `Application`
+itself — a hand-created, standalone `Application` carrying them gets pulled and reconciled exactly
+like an `ApplicationSet`-generated one (the only difference: `multiclusterstatusaggregation` keys
+its `MulticlusterApplicationSetReport` generation off the `application-set` label, which only an
+`ApplicationSet`-owned app has — see Known Limitations #13). Steps 1-3 below are identical for both
+kinds; only step 4 (the takeover) branches, since a standalone app has no template to edit.
+
+### The verified sequence: transform the existing ApplicationSet's template in place
+
+The pull-model `ApplicationSet`'s own template is *already* the durable, self-enforcing source of
+truth for the generated `Application` object (that's why Step 2 below works at all — anything you
+change in the template, the `ApplicationSet` controller keeps re-asserting on the live object,
+including fields you didn't touch). Migrating to argocd-agent means changing what that template
+*says* — from "pull-model, hub-side placeholder" to "agent-routed, hub-dispatched" — never
+replacing the object it manages.
+
+1. **Disable the basic pull model hub-wide** via the `multicluster-integrations-config` ConfigMap
+   (see "Disabling the Basic Pull Model" above) and restart the pod. This freezes every existing
+   pull-model `ManifestWork`'s `applications` manifestConfig to `updateStrategy: ReadOnly` in one
+   pass — no need to find and patch it by hand per app. This stops the spoke's klusterlet
+   work-agent from re-asserting/enforcing the delivered Application's spec, without deleting
+   anything: drifting the spoke Application's `spec.syncPolicy` or a label afterward is not
+   reverted, while `statusFeedBackRules` (health/sync/operation status) keeps flowing to the hub the
+   whole time. **Never delete any pull-model ManifestWork, at any point, ever** — see "Designs that
+   were rejected" below; this holds regardless of which overall design you use.
+2. **Enable `argoCDAgent` on the SAME `GitOpsCluster`** (patch it in place; if the cluster never had
+   `gitopsAddon` at all, this is the first time it gets set, which is fine) — do this **before**
+   touching the `ApplicationSet` template's destination (step 4), so the agent cluster secret
+   already exists by the time the destination needs to resolve against it. Wait for
+   `AddOnDeploymentConfig`'s `ARGOCD_AGENT_ENABLED=true` (a few reconcile passes — cert chain
+   generation is sequential, this is the "Expected Waits (Not Bugs)" pattern, not a stuck reconcile)
+   and for `cluster-<name>` to appear in the ArgoCD namespace with the
+   `argocd-agent.argoproj-labs.io/agent-name` label.
+3. **If the managed cluster already had its OWN, differently-named ArgoCD CR** (e.g. a manually
+   installed default `openshift-gitops` instance, as opposed to the addon-managed
+   `acm-openshift-gitops` one that argocd-agent mode creates) — **delete that old ArgoCD CR now.**
+   ArgoCD's core settings (`argocd-cm`, `argocd-rbac-cm`, `argocd-secret`, etc.) are shared
+   per-namespace, not per-CR-instance; two ArgoCD CRs in the same namespace fight over them
+   continuously (observed live: `argocd-server` stuck restarting on `"url modified. restarting"`
+   forever). Deleting the old ArgoCD CR is safe — it does not cascade to the Applications or
+   real workloads it was reconciling (those aren't Kubernetes-owned by the ArgoCD CR itself), only
+   to the ArgoCD control-plane components (application-controller, repo-server, redis, server).
+   Confirmed live: the managed pod's `uid` was unchanged across this deletion. This step does not
+   apply if the cluster's ArgoCD instance was already the addon-managed `acm-openshift-gitops` one.
+   Then wait for the agent pod to reach 2 consecutive stable `Running` samples.
+4. **Take over the app** — this is the actual takeover, and the only step that touches the app's own
+   identity. Which object you patch depends on whether the app has an `ApplicationSet` owner
+   (`kubectl get applications.argoproj.io $APP_NAME -n $ARGOCD_NS -o jsonpath='{.metadata.ownerReferences}'`):
+
+   **`ApplicationSet`-owned**: patch the `ApplicationSet`'s template in place — the
+   `ApplicationSet` controller re-asserts the change onto the existing `Application`:
+   - remove the pull-specific label (`apps.open-cluster-management.io/pull-to-ocm-managed-cluster`)
+   - remove the two `ocm-managed-cluster`/`ocm-managed-cluster-app-namespace` annotations
+   - remove `argocd.argoproj.io/skip-reconcile` (this one now needs to come OFF, unlike the
+     rejected designs below — the whole point is for this Application to actually be reconciled
+     now, by the agent, instead of sitting inert)
+   - change `spec.destination` from the literal `server: https://kubernetes.default.svc` to
+     `name: '{{name}}'`, which resolves through the agent cluster secret from step 2
+
+   ```bash
+   kubectl patch applicationset $PULL_APPSET -n $ARGOCD_NS --type=json -p='[
+     {"op":"remove","path":"/spec/template/metadata/labels/apps.open-cluster-management.io~1pull-to-ocm-managed-cluster"},
+     {"op":"remove","path":"/spec/template/metadata/annotations/apps.open-cluster-management.io~1ocm-managed-cluster"},
+     {"op":"remove","path":"/spec/template/metadata/annotations/apps.open-cluster-management.io~1ocm-managed-cluster-app-namespace"},
+     {"op":"remove","path":"/spec/template/metadata/annotations/argocd.argoproj.io~1skip-reconcile"},
+     {"op":"remove","path":"/spec/template/spec/destination/server"},
+     {"op":"add","path":"/spec/template/spec/destination/name","value":"{{name}}"}
+   ]'
+   ```
+
+   **Standalone** (no `ApplicationSet`): there's no template — patch the `Application` object
+   itself, directly and once (nothing else re-asserts its spec, so this is permanent). Same fields,
+   but on `/metadata` and `/spec` directly, and `destination.name` is the literal cluster name
+   (there's no `{{name}}` generator to template it):
+
+   ```bash
+   kubectl patch applications.argoproj.io $APP_NAME -n $ARGOCD_NS --type=json -p='[
+     {"op":"remove","path":"/metadata/labels/apps.open-cluster-management.io~1pull-to-ocm-managed-cluster"},
+     {"op":"remove","path":"/metadata/annotations/apps.open-cluster-management.io~1ocm-managed-cluster"},
+     {"op":"remove","path":"/metadata/annotations/apps.open-cluster-management.io~1ocm-managed-cluster-app-namespace"},
+     {"op":"remove","path":"/metadata/annotations/argocd.argoproj.io~1skip-reconcile"},
+     {"op":"remove","path":"/spec/destination/server"},
+     {"op":"add","path":"/spec/destination/name","value":"'"$CLUSTER_NAME"'"}
+   ]'
+   ```
+
+   The hub `Application`'s `.metadata.uid` **must not change** across this patch — it's a genuine
+   in-place field update, not a delete/recreate: for the `ApplicationSet`-owned case, the
+   `ApplicationSet` controller reconciles an existing same-name Application by patching it, not by
+   replacing it; for the standalone case, it's simply the same direct `kubectl patch` target. If
+   the uid changes, something deleted and recreated the object instead of updating it — stop and
+   investigate before proceeding. The Application goes `Synced` within seconds — **but see step 5
+   below before trusting that this means the agent is actually managing it.** Also confirm the
+   propagation controller is permanently inert with a touch-test (annotate the app, confirm the
+   ManifestWork's `.metadata.generation` does not bump).
+5. **Confirm genuine agent management — do not skip this.** The `Synced` status from step 4 can be
+   misleading. This app was, by definition, delivered to the spoke at least once via the classic
+   pull model — the klusterlet work-agent applied it there directly as a plain object. That
+   pre-existing spoke-side copy is invisible to argocd-agent's own bookkeeping (it has no record of
+   ever creating it), so the agent cannot take real control of it. Step 4 only changes the hub's
+   view; the spoke's copy is not automatically replaced and can keep being reconciled by whatever
+   was already reconciling it before, which still reports back `Synced` even though the agent isn't
+   managing anything. Check directly:
+   ```bash
+   kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n $ARGOCD_NS -o jsonpath='{.spec.destination}'
+   ```
+   - `{"name":"in-cluster", ...}` (or another agent-resolved name) — genuine agent control already
+     achieved, nothing more to do.
+   - `{"server":"https://kubernetes.default.svc", ...}` (the old pull-model value) — not yet taken
+     over. Replace the stale spoke copy: remove `syncPolicy.automated` on the **spoke's** copy
+     first (so the delete below doesn't prune the real resources), strip its `finalizers` to `[]`
+     and delete it directly on the spoke, confirm the real workload's pod `uid` is unchanged, then
+     nudge a fresh dispatch from the hub (any harmless annotation touch — the first create attempt
+     right after the stale copy disappears can race and silently fail once). Recheck
+     `spec.destination` on the spoke again after ~30s; it should now be `name`-based. Confirmed
+     live for both `ApplicationSet`-owned and standalone apps: the workload's pod `uid` never
+     changes across this replacement, because `automated` (and its `prune: true`) was removed from
+     the spoke copy before it was deleted.
+
+That's the whole migration. **No new `Application`, no new `ApplicationSet`, nothing to detach or
+delete afterward** — for the `ApplicationSet`-owned case, the same `ApplicationSet` that generated
+the pull-model app is now the permanent, ongoing manager of the agent-dispatched one, exactly like
+any other agent-mode ApplicationSet; for the standalone case, the `Application` you patched is now
+a normal, permanent agent-dispatched app with nothing else managing it. The old, now-`ReadOnly`
+`ManifestWork` is the only leftover either way, and it's inert — leave it in place permanently (see
+below for why deleting it later is still a bad idea).
+
+### Designs that were rejected (and why)
+
+Two earlier designs were tried, both created a **second** Application/ApplicationSet instead of
+transforming the original in place, and both were rejected once their actual failure modes were
+understood:
+
+1. **Strip the old Application's `ownerReferences`, delete the old `ApplicationSet`, then create a
+   NEW agent `ApplicationSet` reusing the exact same Application name.** This passed every
+   immediate, automated check across 3 script cycles and then **destroyed the live
+   Deployment/Service** when the identical steps were replayed manually with realistic pauses
+   between them. Root cause: deleting an `ApplicationSet` that still (or very recently did) own an
+   Application carrying `resources-finalizer.argocd.argoproj.io` triggers a delete-cascade that is
+   **not instantaneous** — it can take real minutes to finish. The fast automated checks sampled a
+   window where the bookkeeping objects were already gone but the cascade toward the real resources
+   hadn't arrived yet.
+2. **Create a NEW agent `ApplicationSet` with a DIFFERENT Application name** (e.g. `<name>-agent`),
+   leaving the old pull-model `ApplicationSet`/Application alone, then separately detach the old one
+   (finalizer-strip, then delete directly on the spoke). This one was actually safe — proven with
+   3 full cycles and extended waits — but is objectively worse than transforming in place: it
+   creates a second, differently-named `Application` object for something that is, from the user's
+   perspective, the same app; it needs an explicit detach step for the old one; and — discovered
+   while tearing down THIS test's own demo apps afterward — **deleting an `ApplicationSet` whose
+   generated Application has `resources-finalizer.argocd.argoproj.io` and `automated.prune: true`
+   is *always* dangerous, permanently, not just during migration** — the exact same destructive
+   cascade from design #1 reproduced again, unrelated to migration, just from ordinary test
+   cleanup. Transforming the existing `ApplicationSet` in place (the sequence above) has no
+   `ApplicationSet` deletion anywhere in it, so this whole class of hazard never comes up.
+
+**Standing caution, not specific to migration**: never delete an `ApplicationSet` whose generated
+`Application` has an active `resources-finalizer.argocd.argoproj.io` *while `syncPolicy.automated`
+is still set* — that combination is what deletes the real managed resources. This applies to
+decommissioning a **still-pull-model** app (one you've decided not to migrate): disable
+`syncPolicy.automated` on the `ApplicationSet`'s template first, confirm that reached the live
+Application (`spec.syncPolicy` no longer has `automated`), **then delete the `ApplicationSet`**,
+and only then strip the orphaned Application's `finalizers` to `[]` and delete it directly.
+Confirmed live this order the other way around does not reliably work: with the `ApplicationSet`
+still present, stripping the Application's finalizers to `[]` gets silently reverted — something
+(the `ApplicationSet` controller's own periodic template reconcile, independent of `automated`)
+re-adds `resources-finalizer.argocd.argoproj.io` moments later, and a `kubectl delete --wait=true`
+issued right after the strip times out waiting on a finalizer that's already back. Deleting the
+`ApplicationSet` first removes whatever keeps re-adding it, and is safe specifically because
+`automated` (and therefore the prune-on-delete cascade) was already confirmed off the live
+Application before that delete — the real workload's pod `uid` was confirmed unchanged across this
+sequence.
+
+**Force-stripping the finalizer is wrong once an app has already been migrated — prefer a normal
+delete, and always verify the spoke copy is actually gone afterward regardless.** The force-strip
+technique above exists because a still-pull-model app's destination is a fake, unreachable URL, so
+ArgoCD's own finalize-then-remove-finalizer flow can never complete on its own. Once an app is
+agent-routed (post-migration), its destination is real and reachable, so a normal
+`kubectl delete applications.argoproj.io $APP_NAME -n $ARGOCD_NS --wait=true` should be preferred
+(force-stripping pre-emptively guarantees the relay-to-agent never gets a chance to happen at all).
+
+**But even a clean, non-force-stripped delete is not guaranteed to relay to the agent — always
+explicitly verify the spoke's copy is actually gone, every time.** Confirmed live, for apps that
+existed before argoCDAgent was ever enabled on their cluster (true of any migrated pull-model app,
+by definition): in one case the relay was rejected outright, logged on the agent as `source UID
+annotation is not found for app: <name>`, leaving the hub object stuck `Terminating` until its
+finalizer was cleared manually; in another, a `--wait=true` delete completed on the hub with no
+error at all, yet the spoke's mirrored `Application` (and its real workload) was silently left
+behind regardless. Both were only caught by directly checking the spoke:
+
+```bash
+kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n $ARGOCD_NS
+# if found with no corresponding hub object, it's an orphan -- delete it directly, on the spoke:
+kubectl --kubeconfig $SPOKE_KUBECONFIG delete applications.argoproj.io $APP_NAME -n $ARGOCD_NS --wait=true
+```
+
+An orphaned spoke copy isn't just inert leftover clutter — it keeps actively reconciling its
+resources and will fight any later, unrelated app that reuses the same destination namespace and
+resource names, both apps repeatedly overwriting each other's `argocd.argoproj.io/tracking-id`,
+with the affected app flapping `Synced`/`OutOfSync` indefinitely until the orphan is removed.
+
+### Other gotchas hit while building and testing this
+
+- **An immediate post-action check is not sufficient proof of safety — always re-verify after a
+  real wait.** This is the single biggest lesson from the rejected design #1 above: a pod `uid`
+  unchanged 1 second after a risky operation does not mean the operation was safe, only that
+  nothing had cascaded *yet*. Every step in the sequence above was re-confirmed after an explicit
+  ~3 minute wait, not just immediately.
+- **Deleting the wrong Policy name leaves the ArgoCD CR fighting cleanup forever.** The governance
+  root `Policy` lives in the ArgoCD namespace as `<gitopscluster-name>-argocd-policy`; the
+  *replica* in the managed cluster's own namespace is named
+  `<argocd-namespace>.<gitopscluster-name>-argocd-policy` (root namespace prefixed). Deleting only
+  the replica — or using the un-prefixed name in the managed cluster's namespace — does nothing:
+  the root `Policy` keeps re-enforcing, so `config-policy-controller` on the spoke recreates the
+  ArgoCD CR every time a `ManagedClusterAddOn` pre-delete cleanup Job deletes it, until the Job's
+  own timeout is exhausted and it fails permanently, wedging the MCA in `Terminating`. Always
+  delete the root `Policy` + its `PlacementBinding` in the ArgoCD namespace, before deleting the
+  MCA, per the documented cleanup order.
+- **A default OLM install of the operator does NOT get the same RBAC the addon normally
+  provisions.** A manually-installed (not addon-managed) ArgoCD instance's application-controller
+  ServiceAccount is scoped read-only outside its own namespace by default — the very first sync of
+  anything into another namespace fails with `services is forbidden` / `deployments.apps is
+  forbidden` and exhausts ArgoCD's 5-retry budget. Grant `cluster-admin` (or a narrower equivalent)
+  to `<argocd-name>-argocd-application-controller` before the first sync, same pattern as the
+  Hybrid Mode / RBAC-before-first-sync guidance elsewhere in this doc — and note the SA name
+  changes when the ArgoCD instance's own name changes (e.g. after step 4 above swaps
+  `openshift-gitops` for `acm-openshift-gitops`).
+- **A shell script's `wait_for`-style helper that shells out via `bash -c "..."` does not inherit
+  parent shell functions or variables.** If `wait_for` (or any retry loop) spawns a *new* bash
+  process to evaluate its condition, any helper functions (e.g. a `hub() { kubectl --kubeconfig
+  ... }` wrapper) and the variables they close over must be `export -f`'d and `export`'d
+  respectively, or the subshell silently falls through to kubectl's `localhost:8080` default and
+  the condition can never become true — the loop just hangs forever with no error, which looks
+  identical to a slow reconcile.
+- **kubectl JSONPath bracket-filters on dotted annotation/label keys are fragile** (e.g.
+  `{.items[?(@.metadata.annotations.foo\.bar=='x')]}`). Prefer `-o json | python3 -c "..."` for
+  anything beyond a simple field path — it's slower to write but doesn't silently return empty on
+  syntax the kubectl JSONPath parser doesn't like.
+- **ArgoCD component pod label selectors are not always `app.kubernetes.io/component=<name>`** —
+  e.g. the application-controller StatefulSet pod carries
+  `app.kubernetes.io/name=<argocd-cr-name>-application-controller`, not a generic `component`
+  label. When scripting a wait condition, prefer matching on the pod *name* (`-o name | grep
+  application-controller`) over guessing a label schema.
+- **`kubectl get subscription` is ambiguous on an ACM hub**, same trap as `kubectl get application`
+  documented under Troubleshooting — both `apps.open-cluster-management.io/v1 Subscription` (OCM's
+  classic app-lifecycle CRD) and `operators.coreos.com/v1alpha1 Subscription` (OLM) register the
+  same plural. Always use `kubectl get subscriptions.operators.coreos.com` when checking OLM
+  install state on a hub or spoke that also has ACM's app-lifecycle CRDs installed.
+- **A duplicate `OperatorGroup` in the same namespace silently breaks OLM resolution.** If a
+  namespace already has one (e.g. a leftover `gitops-addon-operator-group` from a previous
+  addon-managed install), creating a second one produces `MultipleOperatorGroupsFound` and the
+  `Subscription` never progresses past `CatalogSourcesUnhealthy: false` / no `InstallPlan` at all —
+  no obvious error on the `Subscription` itself, only on the `OperatorGroup`'s own status
+  conditions. Check `kubectl get operatorgroup -A -o yaml` for this condition before assuming a
+  stuck install is a catalog or network problem.
+
 ## Creating and Importing a Kind Managed Cluster
 
 ```bash
@@ -308,6 +787,30 @@ GitOpsCluster deletion is a no-op (no finalizer). You must delete resources in t
 
 **Key constraints**: GitOpsCluster BEFORE MCAs. Policy BEFORE MCAs. ADC/AddOnTemplate must still exist when MCAs are deleted.
 
+**Confirm an Application is actually gone (not just `--wait=false` "issued") before deleting the
+GitOpsCluster/agent/cluster-secret underneath it — for an agent-routed (post-migration) app,
+skipping this can wedge it in `Terminating` forever.** If the Application still carries
+`resources-finalizer.argocd.argoproj.io` when you request its deletion, some ArgoCD app-controller
+has to actually finish pruning against its `spec.destination` before the finalizer clears — for a
+`destination.name`-based (agent-routed) app, that means the agent's own ArgoCD instance on the
+spoke, not the hub. If you delete the `GitOpsCluster`/MCA (tearing down the agent) or the cluster
+secret the destination name resolves through while that finalizer is still pending, nothing can
+ever finish the prune, and the Application sits `Terminating` indefinitely with
+`status.conditions[].type: DeletionError` referencing a destination that no longer exists.
+Confirmed live: with two migrated Applications from two different test cycles both targeting a
+cluster named `ocp-cluster1`, letting cycle 1's stuck deletion linger while cycle 2 created its own
+(differently-shaped) `ocp-cluster1`-named cluster secret caused cycle 1's app-controller retry to
+resolve `ocp-cluster1` to *cycle 2's* secret and report `DeletionError`s against a completely
+unrelated fake URL — a confusing, misleading symptom that's really just "the destination this app
+needs to reach doesn't exist by that name anymore." Once the real workload is independently
+confirmed gone (e.g. manually verified on the spoke), it's safe to force-clear the stuck
+finalizer directly (`kubectl patch applications.argoproj.io <name> -n <ns> --type=merge -p
+'{"metadata":{"finalizers":null}}'`) — same "target confirmed dead, mechanism to clear it
+naturally can't work anymore" reasoning as the documented `ManagedClusterAddOn`
+`addon-pre-delete`-finalizer exception above. Prefer not needing this: always
+`kubectl delete applications.argoproj.io <name> -n <ns> --wait=true` (or poll for `NotFound`)
+before proceeding to the next cleanup step, not `--wait=false`.
+
 ## Troubleshooting
 
 ### Apps Stuck at OutOfSync/Missing After RBAC Fix
@@ -350,6 +853,24 @@ kubectl -n ocm rollout restart deployment/multicluster-operators-application
 1. Check principal pod: `kubectl get pods -n openshift-gitops -l app.kubernetes.io/component=principal`
 2. Check principal logs: `kubectl logs -n openshift-gitops -l app.kubernetes.io/component=principal --tail=50`
 3. Check agent logs on spoke: `kubectl logs -n openshift-gitops -l app.kubernetes.io/part-of=argocd-agent --tail=50`
+
+### Basic Pull Model: Blank Cluster Secret Creation Fails ("found existing non-ACM ArgoCD clusters secrets")
+Symptom: `GitOpsCluster` status shows `ClustersRegistered: False`, message `found existing non-ACM
+ArgoCD clusters secrets for cluster: <name>`. Cause: a stale/orphaned cluster secret for that
+cluster already exists in the ArgoCD namespace — most commonly an old argocd-agent secret
+(`argocd-agent.argoproj-labs.io/agent-name` label, `managed-by: argocd-agent` annotation) left
+behind by a previously deleted `GitOpsCluster` that had agent mode enabled for the same cluster
+name. The blank-secret creation path refuses to overwrite a secret it doesn't recognize as its own
+placeholder. Fix: confirm the existing secret really is orphaned (its owning `GitOpsCluster` is
+gone), then delete it — the next reconcile creates a fresh blank secret.
+
+### `kubectl get application` Silently Returns Nothing on an ACM Hub
+An ACM hub has more than one CRD registered under the bare kind `Application` (ArgoCD's
+`applications.argoproj.io` and the older `applications.app.k8s.io` from the classic
+subscription/channel model). An unqualified `kubectl get application` can resolve to the wrong one
+and print `No resources found` even though the ArgoCD Application you're looking for exists.
+Always use the fully-qualified `kubectl get applications.argoproj.io` when inspecting pull-model
+or agent-mode Applications on a real hub.
 
 ### Hub App-Controller Fights the Principal Over an Autonomous Mirror's Status
 Symptom: an autonomous-mode Application mirrored to the hub flips `status.sync.status` back to
@@ -446,6 +967,72 @@ namespace with its own agent-connected ArgoCD instance) has been removed.
   app-controllers) in whatever destination namespaces those apps create — do this **before**
   creating the AppSet, or the first sync attempt exhausts ArgoCD's 5-retry budget and self-heal
   won't retry a revision that already failed that many times.
+
+### Basic Pull Model (Classic ManifestWork-Based Delivery)
+
+The original (2023) integration, predating argocd-agent and still shipping by default alongside
+it — the two are **intentionally coexisting alternatives, not a deprecated/replacement pair**.
+Nothing in the code or git history marks the pull model itself as deprecated (only the
+`MulticlusterApplicationSetReport` v1alpha1 CRD carries a Kubernetes-convention deprecation
+warning — a data-model sunset note, not a statement that the mechanism is going away).
+
+**Key distinction from argocd-agent**: no new agent process, no gRPC, no principal/cert
+machinery. It reuses the **klusterlet work-agent every managed cluster already has** (the same
+channel used for Policies and classic Subscriptions) via the standard `ManifestWork` API.
+
+Data flow:
+1. Hub creates a **blank/dummy cluster secret** per target cluster (`createBlankClusterSecrets`,
+   forced `true` whenever `gitopsAddon` is enabled) — `server: https://<cluster>-control-plane`,
+   a deliberately fake/unreachable URL. Its only purpose is making ArgoCD's `ApplicationSet`
+   `clusterDecisionResource` generator treat the cluster as a valid destination; nothing ever
+   actually connects to that URL.
+2. The **propagation controller** (`propagation-controller/application/`, part of the
+   `multicluster-integrations` deployment) watches `Application` objects cluster-wide for label
+   `apps.open-cluster-management.io/pull-to-ocm-managed-cluster: "true"` plus annotation
+   `apps.open-cluster-management.io/ocm-managed-cluster: <cluster-name>`. On match, it wraps the
+   Application (destination rewritten to `https://kubernetes.default.svc`, i.e. "reconcile
+   in-cluster" — meaning in the *spoke's* own cluster once delivered) plus its `Namespace` and
+   `AppProject` (skipped if it's just the default `default`/`openshift-gitops` pair, since every
+   ArgoCD install already has that) into a `ManifestWork` in the target cluster's hub namespace,
+   with `FeedbackRules` requesting health/sync/operation status back.
+3. The spoke's own existing klusterlet work-agent pulls that `ManifestWork` down and applies it —
+   no new network channel, no addon-specific delivery path.
+4. The spoke's own ArgoCD (installed by `gitopsaddon`, same as agent mode, just without the
+   `argoCDAgent` block) reconciles the delivered Application against its local API server.
+5. Status returns two ways: `ManifestWork.status.resourceStatus` feedback is consumed by
+   `multiclusterstatusaggregation`, merged with fine-grained detail polled from ACM's
+   `search-search-api` by `gitopssyncresc` (communicated between the two sidecar containers via a
+   shared `emptyDir`, not an API), into a `MulticlusterApplicationSetReport` CR — and separately,
+   `application_status_controller` (same `propagation-controller` binary) watches that report and
+   reflects health/sync/operation state directly onto the hub's own placeholder `Application`
+   object, plus a synthetic `AdditionalStatusReport` condition pointing users at the report and
+   the spoke's own Application for full detail.
+6. Only Applications generated by an `ApplicationSet` (i.e. carrying an `ApplicationSet`
+   `ownerReference`) get the `apps.open-cluster-management.io/application-set` label on their
+   `ManifestWork` — a hand-created, non-ApplicationSet-owned `Application` still gets pulled and
+   reconciled, but produces no `MulticlusterApplicationSetReport` (`multiclusterstatusaggregation`
+   only lists `ManifestWork`s carrying that label).
+
+**Coexistence with hybrid mode / argocd-agent**: if the hub's own app-controller is enabled
+(hybrid mode, `controller.enabled: true`) and the pull-model placeholder Application's
+`destination.server` is the in-cluster address, the hub app-controller would otherwise try to
+reconcile that same placeholder locally, on top of the propagation controller delivering it to the
+spoke. Set `argocd.argoproj.io/skip-reconcile: "true"` directly on the pull-model Application
+itself (not just on cluster secrets — this is the same generic upstream ArgoCD annotation, applied
+at a different level) to keep the hub's copy inert.
+
+**OCP-only**: this integration is supported only for OCP managed clusters. Both OCP and non-OCP
+spokes get a real ArgoCD instance from `gitopsaddon`, but the pull model has not been validated
+against the non-OCP embedded-chart path.
+
+**`local-cluster` support is currently dormant, not actively gated**: an earlier iteration
+supported pulling Applications onto `local-cluster` itself, via a dedicated `gitopsaddon`-deployed
+ArgoCD instance in a `local-cluster` namespace. That dedicated instance was removed when hybrid
+mode replaced it with the plain in-cluster `cluster-local-cluster` secret (see "Hybrid Mode"
+above), and the e2e coverage for pull-model-on-local-cluster was deleted at the same time. No
+explicit code-level guard currently blocks targeting `local-cluster` with a pull-model Application
+(unlike the Maestro variant, which explicitly skips it), but the mechanism it used to depend on no
+longer exists in the same shape — treat this path as unverified.
 
 ### Package Structure
 
@@ -744,6 +1331,18 @@ one.
 8. **OCP OLM timing**: 30-120s. Use 600s timeouts.
 9. **DBM must match principal and agent**: Mismatched = "Resource not found" in UI.
 10. **Agent SA view ClusterRole**: Not auto-provisioned. Add manually or via Policy.
+11. **Basic pull model is OCP-only**: not validated/supported against non-OCP (embedded Helm
+    chart) managed clusters. See "Basic Pull Model" under Architecture.
+12. **Basic pull model on `local-cluster` is dormant**: the dedicated `local-cluster`-namespace
+    ArgoCD instance it depended on was removed by hybrid mode; no code-level guard blocks it, but
+    it is unverified. See "Basic Pull Model" under Architecture.
+13. **Basic pull model status aggregation requires an `ApplicationSet` owner**: a hand-created
+    `Application` with the pull label/annotation still gets delivered and reconciled, but produces
+    no `MulticlusterApplicationSetReport` — only `ApplicationSet`-generated Applications get the
+    `application-set` label needed for `multiclusterstatusaggregation` to pick them up.
+14. **Never delete a pull-model `ManifestWork` for an app you want to keep**: proven destructive in
+    live testing regardless of `updateStrategy: ReadOnly` or an explicit `orphaningRules` entry —
+    see "Migrating an App from Basic Pull Model to argocd-agent" above for the actual safe sequence.
 
 ## Container Registry
 

--- a/cmd/propagation/main.go
+++ b/cmd/propagation/main.go
@@ -39,6 +39,7 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	workv1 "open-cluster-management.io/api/work/v1"
 	appsetreportV1alpha1 "open-cluster-management.io/multicloud-integrations/pkg/apis/appsetreport/v1alpha1"
+	"open-cluster-management.io/multicloud-integrations/pkg/pullmodelconfig"
 	"open-cluster-management.io/multicloud-integrations/propagation-controller/application"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -169,6 +170,26 @@ func main() {
 		} else {
 			setupLog.Error(err, "failed to find CRD applications.argoproj.io, checking again after 10s")
 			time.Sleep(10 * time.Second)
+		}
+	}
+
+	pullModelCfg, err := pullmodelconfig.LoadOrCreate(context.TODO(), mgr.GetClient())
+	if err != nil {
+		setupLog.Error(err, "unable to load multicluster-integrations-config, defaulting to basic pull model enabled")
+		pullModelCfg = &pullmodelconfig.ControllerConfig{}
+	}
+
+	basicPullModelDisabled := pullModelCfg.PullModel.Basic.Disabled
+
+	if basicPullModelDisabled {
+		setupLog.Info("basic pull model is disabled via multicluster-integrations-config; sweeping existing ManifestWorks to ReadOnly")
+
+		if err := application.SweepManifestWorksToReadOnly(context.TODO(), mgr.GetClient()); err != nil {
+			// Best-effort: Reconcile is already disabled below regardless of whether this
+			// sweep succeeds, so a failure here doesn't compromise the "no new ManifestWork
+			// gets created" guarantee -- it just means pre-existing ManifestWorks may need
+			// this to be retried (e.g. on the next pod restart, where it will run again).
+			setupLog.Error(err, "pull-model disable sweep did not complete successfully")
 		}
 	}
 

--- a/docs/basic-pull-to-argocd-agent-migration.md
+++ b/docs/basic-pull-to-argocd-agent-migration.md
@@ -1,0 +1,480 @@
+# Migrating from the Basic Pull Model to argocd-agent
+
+This is a runbook for moving apps off the classic ManifestWork-based "basic pull model" (see
+CLAUDE.md → "Basic Pull Model" under Architecture) and onto argocd-agent, without creating a new
+`Application`/`ApplicationSet` and without disrupting the real workload underneath. For the
+architectural background and the two rejected designs that led to the approach below, see CLAUDE.md
+→ "Migrating an App from Basic Pull Model to argocd-agent".
+
+## What this achieves
+
+- **argocd-agent takes over the exact same `Application` object** — same name, same namespace, same
+  `.metadata.uid`. No new `Application` or `ApplicationSet` is ever created.
+- The app's real workload (Deployment/Service, etc.) is never deleted or recreated — no pod restart
+  happens at any point.
+- Once complete, the old pull-model machinery (`multicluster-integrations`'s propagation,
+  search-sync, and aggregation controllers) never touches the app again.
+- The agent genuinely takes over reconciliation — not just the hub's view of the app. Getting this
+  right requires one more step than you might expect (Step 5): the app's spoke-side copy, delivered
+  there by the classic pull model, is not automatically hand-off-able to the agent and needs to be
+  explicitly replaced. Skipping Step 5 leaves an app that *looks* migrated (`Synced` on both hub and
+  spoke) but is still being reconciled the old way underneath, with the agent doing nothing.
+
+## Two kinds of pull-model apps
+
+Not every basic-pull-model `Application` comes from an `ApplicationSet`. The pull label
+(`apps.open-cluster-management.io/pull-to-ocm-managed-cluster: "true"`) and the
+`ocm-managed-cluster`/`ocm-managed-cluster-app-namespace`/`skip-reconcile` annotations are all that
+the propagation controller actually requires — a hand-created, standalone `Application` carrying
+them gets pulled and reconciled on the spoke exactly the same way (the one difference is purely
+cosmetic: only `ApplicationSet`-owned apps get a `MulticlusterApplicationSetReport`, since
+`multiclusterstatusaggregation` keys off the `application-set` label that only an owned app has).
+
+Which kind an app is changes **only** the takeover step (Step 4 below):
+
+- **`ApplicationSet`-owned app**: take it over by editing the `ApplicationSet`'s template. The
+  `ApplicationSet` controller then re-asserts the change onto the existing `Application` in place.
+- **Standalone `Application`** (no `ApplicationSet` owner): there's no template to edit — take it
+  over by patching the `Application` object itself, directly and once. Nothing re-asserts a
+  standalone app's spec, so a direct patch is permanent with no template to keep in sync afterward.
+
+Check which kind you have before starting:
+
+```bash
+kubectl get applications.argoproj.io $APP_NAME -n $ARGOCD_NS -o jsonpath='{.metadata.ownerReferences}'
+```
+
+An empty result means standalone; an `ApplicationSet` entry means `ApplicationSet`-owned. Steps 1-3
+below are identical either way — only Step 4 branches. Step 5 applies to both, and is not optional
+— see why in Step 5 itself.
+
+## Overview
+
+The migration has two parts:
+
+1. **Disable the basic pull model, hub-wide, once.** This is a single ConfigMap edit plus a pod
+   restart. It stops all three basic-pull-model controllers from reconciling anything, and freezes
+   every existing pull-model `ManifestWork` in place (`updateStrategy: ReadOnly`) so spokes stop
+   re-enforcing the delivered `Application` specs — without deleting anything or touching the real
+   workloads. Do this before migrating any individual app. This step covers `ApplicationSet`-owned
+   and standalone apps identically — the sweep matches on the `Application`/`ManifestWork`'s own
+   annotations and labels, not on how the `Application` was created.
+2. **Per managed cluster, transform each app over to argocd-agent.** This is the part that actually
+   changes how an app is dispatched and reconciled — repeat Steps 4-5 for every `ApplicationSet` and
+   every standalone `Application` you want to move (Steps 2-3 are per-cluster, not per-app — do them
+   once per managed cluster, then migrate every app on that cluster with Steps 4-5).
+
+## Before you start
+
+You need:
+- Agent-mode prerequisites already on the hub: `ManagedClusterSetBinding` for `global` in the
+  ArgoCD namespace, the default `AppProject` patched with `destinations: [{name: "*", ...}]`, and
+  the hub's own ArgoCD instance already running as an argocd-agent principal
+  (`spec.argoCDAgent.principal.enabled: true`). See CLAUDE.md → "Agent Mode Setup — Full YAML" if
+  any of this isn't done yet.
+- For each app you're migrating: the hub `GitOpsCluster` object managing its target cluster (call
+  its name `$GITOPSCLUSTER`), the app's name (`$APP_NAME`) and namespace (`$ARGOCD_NS`, normally
+  `openshift-gitops`), and the target `ManagedCluster` name (`$CLUSTER_NAME`). If the app is
+  `ApplicationSet`-owned, also note the `ApplicationSet`'s name (`$PULL_APPSET`).
+
+This works whether the pull model was set up via `gitopsAddon.enabled: true` or via
+`createBlankClusterSecrets: true` directly — the latter is how the pull model can exist completely
+independent of the addon; see CLAUDE.md → "Basic Pull Model" under Architecture.
+
+**Basic pull model is OCP-only.** This runbook applies to apps delivered to OCP managed clusters.
+
+## Step 1 — Disable the basic pull model (one-time, hub-wide)
+
+This step covers every existing pull-model app across every managed cluster in a single pass — you
+do not need to repeat it per app or per cluster, and you do not need to manually find and patch any
+`ManifestWork` yourself.
+
+1. Find the namespace the `multicluster-integrations` Deployment runs in (normally
+   `open-cluster-management`):
+
+   ```bash
+   kubectl get deployment -A --field-selector metadata.name=multicluster-integrations
+   ```
+
+2. Edit (or create, if it doesn't exist yet) the `multicluster-integrations-config` ConfigMap in
+   that namespace:
+
+   ```bash
+   kubectl get configmap multicluster-integrations-config -n <namespace> -o yaml
+   ```
+
+   If it doesn't exist, one of the controller's containers will self-create it with defaults the
+   first time it starts — in that case just wait for it to appear, or create it yourself with the
+   content below.
+
+   Set (or add) `pullModel.basic.disabled: true` under the `config.yaml` key:
+
+   ```bash
+   kubectl patch configmap multicluster-integrations-config -n <namespace> --type=merge -p '{
+     "data": {
+       "config.yaml": "pullModel:\n  basic:\n    disabled: true\n"
+     }
+   }'
+   ```
+
+3. Restart the pod. The reconcile-time guards themselves check this ConfigMap live and would pick
+   up the change within moments even without a restart, but the one-time `ManifestWork` sweep
+   (step 5 below) only ever runs once, at process startup — a restart is what triggers it:
+
+   ```bash
+   kubectl rollout restart deployment multicluster-integrations -n <namespace>
+   kubectl rollout status deployment multicluster-integrations -n <namespace>
+   ```
+
+4. Confirm the disable took effect. The controller-manager container logs a line when it sees the
+   config is disabled, and reports the outcome of the one-time `ManifestWork` sweep:
+
+   ```bash
+   kubectl logs -n <namespace> deployment/multicluster-integrations \
+     -c argocd-pull-integration-controller-manager | grep -E "pull-model disable|disable sweep"
+   ```
+
+   You should see `basic pull model is disabled via multicluster-integrations-config; sweeping
+   existing ManifestWorks to ReadOnly` followed by a summary line like `pull-model disable sweep
+   complete: N patched to ReadOnly, M already ReadOnly, K not pull-model-owned (skipped)`.
+
+5. Confirm every pull-model `ManifestWork` is now `ReadOnly`:
+
+   ```bash
+   kubectl get manifestwork -A -o json | python3 -c "
+   import json, sys
+   d = json.load(sys.stdin)
+   for i in d['items']:
+       ann = i.get('metadata', {}).get('annotations', {}) or {}
+       if 'apps.open-cluster-management.io/hub-application-name' not in ann:
+           continue
+       for mc in i['spec'].get('manifestConfigs', []):
+           ri = mc.get('resourceIdentifier', {})
+           if ri.get('group') == 'argoproj.io' and ri.get('resource') == 'applications':
+               strat = (mc.get('updateStrategy') or {}).get('type')
+               print(i['metadata']['namespace'], i['metadata']['name'], strat)
+   "
+   ```
+
+   Every row should read `ReadOnly`.
+
+What just happened, at the code level:
+- The propagation controller's `Application` and `Application`-status reconcilers now return
+  immediately on every event, for every app — no ManifestWork is created, updated, or deleted by
+  this component from this point on.
+- `gitopssyncresc` (the ACM Search polling loop) and `multiclusterstatusaggregation` (the
+  `MulticlusterApplicationSetReport` generator) both skip their periodic work entirely.
+- Every existing pull-model `ManifestWork` had its `applications` manifest config's
+  `updateStrategy` set to `ReadOnly` — this stops the spoke's klusterlet work-agent from
+  re-asserting the delivered `Application` spec, without deleting anything. Health/sync/operation
+  status feedback continues flowing normally; only spec enforcement stops.
+- None of this touches `pkg/controller/gitopscluster` or anything used by argocd-agent — this is a
+  pure basic-pull-model shutoff switch.
+
+**Never delete a pull-model `ManifestWork`, at any point — before, during, or after this step.**
+Deleting it (even once it's `ReadOnly`) cascades through the delivered Application's
+`resources-finalizer.argocd.argoproj.io` and deletes the real workload resources. Leave every
+pull-model `ManifestWork` in place permanently; once `ReadOnly`, it's inert and harmless.
+
+Record the workload's pod `uid` now, before doing anything else — you'll compare against it after
+every subsequent step:
+
+```bash
+kubectl --kubeconfig $SPOKE_KUBECONFIG get pods -n <dest-namespace> -o jsonpath='{.items[0].metadata.uid}'
+```
+
+## Step 2 — Enable argoCDAgent on the GitOpsCluster
+
+Repeat steps 2-4 for each managed cluster / `ApplicationSet` you're migrating.
+
+Patch the existing `GitOpsCluster` in place — do not create a new one. Do this **before** Step 4's
+template change, so the agent cluster secret already exists by the time the destination needs to
+resolve against it:
+
+```bash
+kubectl patch gitopscluster $GITOPSCLUSTER -n $ARGOCD_NS --type=merge -p '{
+  "spec": {"gitopsAddon": {"enabled": true, "argoCDAgent": {"enabled": true, "mode": "managed"}}}
+}'
+```
+
+Wait for (each can take a few reconcile passes — cert chain generation is sequential, this is
+expected, not a stuck reconcile):
+
+```bash
+# ARGOCD_AGENT_ENABLED flips to true
+kubectl get addondeploymentconfig gitops-addon-config -n $CLUSTER_NAME \
+  -o jsonpath='{.spec.customizedVariables[?(@.name=="ARGOCD_AGENT_ENABLED")].value}'
+
+# agent cluster secret appears on the hub
+kubectl get secret cluster-$CLUSTER_NAME -n $ARGOCD_NS \
+  -o jsonpath='{.metadata.labels.argocd-agent\.argoproj-labs\.io/agent-name}'
+```
+
+## Step 3 — Resolve a pre-existing, differently-named ArgoCD instance (if any)
+
+**Check this even if you think you don't need to.** If the managed cluster already had its own
+ArgoCD instance under a name other than `acm-openshift-gitops` (e.g. a manually installed default
+`openshift-gitops` instance from before this cluster ever used the addon), it now coexists with the
+new addon-managed `acm-openshift-gitops` instance **in the same namespace**. ArgoCD's core settings
+(`argocd-cm`, `argocd-rbac-cm`, `argocd-secret`) are shared per-namespace, not per-instance — two
+ArgoCD CRs in the same namespace fight over them continuously (symptom: `argocd-server` stuck
+permanently restarting on `"url modified. restarting"`).
+
+```bash
+kubectl --kubeconfig $SPOKE_KUBECONFIG get argocd -n $ARGOCD_NS
+# if you see both acm-openshift-gitops AND some other name:
+kubectl --kubeconfig $SPOKE_KUBECONFIG delete argocd <the-other-name> -n $ARGOCD_NS
+```
+
+This is safe — deleting an ArgoCD CR does not cascade to the Applications or real workloads it was
+reconciling (they aren't Kubernetes-owned by the ArgoCD CR), only to its own control-plane
+components (application-controller, repo-server, redis, server). Confirm the workload's pod `uid`
+is unchanged before and after.
+
+Then wait for the agent pod to reach **two consecutive stable `Running` samples**, not just one — a
+crash-looping pod can report `Running` momentarily between restarts:
+
+```bash
+kubectl --kubeconfig $SPOKE_KUBECONFIG get pods -n $ARGOCD_NS -l app.kubernetes.io/part-of=argocd-agent
+```
+
+Wait a couple of minutes and recheck the workload's pod `uid` again before proceeding — an
+immediate check after a risky step is not sufficient proof that it was safe (see "A standing
+caution" below for why).
+
+## Step 4 — The takeover
+
+Pick the case that matches this app (see "Two kinds of pull-model apps" above).
+
+### Case A: the app is generated by an ApplicationSet
+
+Transform the `ApplicationSet`'s own template in place — it's already the durable, self-enforcing
+source of truth for the generated `Application`, so changing what the template *says* changes the
+live object in place, without ever deleting or recreating it.
+
+```bash
+kubectl patch applicationset $PULL_APPSET -n $ARGOCD_NS --type=json -p='[
+  {"op":"remove","path":"/spec/template/metadata/labels/apps.open-cluster-management.io~1pull-to-ocm-managed-cluster"},
+  {"op":"remove","path":"/spec/template/metadata/annotations/apps.open-cluster-management.io~1ocm-managed-cluster"},
+  {"op":"remove","path":"/spec/template/metadata/annotations/apps.open-cluster-management.io~1ocm-managed-cluster-app-namespace"},
+  {"op":"remove","path":"/spec/template/metadata/annotations/argocd.argoproj.io~1skip-reconcile"},
+  {"op":"remove","path":"/spec/template/spec/destination/server"},
+  {"op":"add","path":"/spec/template/spec/destination/name","value":"{{name}}"}
+]'
+```
+
+### Case B: the app is a standalone Application (no ApplicationSet)
+
+There's no template — patch the `Application` object directly, once. Nothing else re-asserts a
+standalone app's spec, so this single patch is permanent:
+
+```bash
+kubectl patch applications.argoproj.io $APP_NAME -n $ARGOCD_NS --type=json -p='[
+  {"op":"remove","path":"/metadata/labels/apps.open-cluster-management.io~1pull-to-ocm-managed-cluster"},
+  {"op":"remove","path":"/metadata/annotations/apps.open-cluster-management.io~1ocm-managed-cluster"},
+  {"op":"remove","path":"/metadata/annotations/apps.open-cluster-management.io~1ocm-managed-cluster-app-namespace"},
+  {"op":"remove","path":"/metadata/annotations/argocd.argoproj.io~1skip-reconcile"},
+  {"op":"remove","path":"/spec/destination/server"},
+  {"op":"add","path":"/spec/destination/name","value":"'"$CLUSTER_NAME"'"}
+]'
+```
+
+Note the one real difference from Case A: `destination.name` is set to the literal `$CLUSTER_NAME`
+value, not the `{{name}}` placeholder — there's no `ApplicationSet` generator to template it, so
+you supply the actual cluster name directly.
+
+### What this changes and why (both cases)
+
+- Removing the pull label and the two `ocm-managed-cluster*` annotations means this app is no
+  longer pull-model-shaped — moot at the code level once Step 1 is done hub-wide, but keeps the
+  object's own metadata honest about what it actually is now.
+- Removing `skip-reconcile` is required — the whole point is for this Application to actually be
+  reconciled now, by the agent, instead of sitting inert on the hub.
+- Changing `destination` from the literal `server: https://kubernetes.default.svc` to a
+  `name`-based destination makes it resolve through the agent cluster secret from Step 2 instead of
+  the fake/hub-local destination — this is what actually routes it through the principal → agent
+  path.
+
+Verify immediately, then again after a real wait (same checks for both cases):
+
+```bash
+# The hub Application's uid must be IDENTICAL before and after this patch. If it changes,
+# something deleted and recreated the object instead of updating it in place -- stop and
+# investigate before proceeding.
+kubectl get applications.argoproj.io $APP_NAME -n $ARGOCD_NS -o jsonpath='{.metadata.uid}'
+
+# Both hub and spoke copies reach Synced
+kubectl get applications.argoproj.io $APP_NAME -n $ARGOCD_NS -o jsonpath='{.status.sync.status}'
+kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n $ARGOCD_NS -o jsonpath='{.status.sync.status}'
+
+# The real workload's pod uid is UNCHANGED from what you recorded in Step 1
+kubectl --kubeconfig $SPOKE_KUBECONFIG get pods -n <dest-namespace> -o jsonpath='{.items[0].metadata.uid}'
+```
+
+Wait a couple of minutes and recheck all three again before considering the app fully migrated.
+
+## Step 5 — Confirm genuine agent management (do not skip this)
+
+The `Synced` status you just checked can be misleading, and this step is not optional. This app
+was, by definition, delivered to the spoke at least once via the classic pull model — the
+klusterlet work-agent applied it there directly, as a plain Kubernetes object. That pre-existing
+copy is invisible to argocd-agent's own bookkeeping: the agent has no record of ever having created
+it, so it cannot take real control of it. Step 4 only changed the **hub's** view of the app; the
+spoke's copy does not automatically get replaced, and can keep being reconciled by whatever was
+already reconciling it before — which, from the hub's perspective, still reports back as `Synced`,
+even though the agent isn't actually managing anything.
+
+Check the spoke's copy directly:
+
+```bash
+kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n $ARGOCD_NS -o jsonpath='{.spec.destination}'
+```
+
+- `{"name":"in-cluster", ...}` (or another agent-resolved name) — the agent already has genuine
+  control. Nothing more to do; skip the rest of this step.
+- `{"server":"https://kubernetes.default.svc", ...}` (the old pull-model value) — the agent has
+  **not** taken over. The spoke's stale copy needs to be replaced:
+
+```bash
+# On the SPOKE: remove automated first, so the delete below does not prune the real resources
+kubectl --kubeconfig $SPOKE_KUBECONFIG patch applications.argoproj.io $APP_NAME -n $ARGOCD_NS \
+  --type=json -p='[{"op":"remove","path":"/spec/syncPolicy/automated"}]'
+
+# On the SPOKE: strip the finalizer and delete the stale copy directly
+kubectl --kubeconfig $SPOKE_KUBECONFIG patch applications.argoproj.io $APP_NAME -n $ARGOCD_NS \
+  --type=merge -p '{"metadata":{"finalizers":[]}}'
+kubectl --kubeconfig $SPOKE_KUBECONFIG delete applications.argoproj.io $APP_NAME -n $ARGOCD_NS --wait=true
+
+# Confirm the real workload survived this (pod uid unchanged from what you recorded earlier)
+kubectl --kubeconfig $SPOKE_KUBECONFIG get pods -n <dest-namespace> -o jsonpath='{.items[0].metadata.uid}'
+
+# On the HUB: nudge a fresh dispatch -- the very first create attempt after the stale copy is
+# removed can race and silently fail once; any harmless metadata touch forces a clean retry
+kubectl annotate applications.argoproj.io $APP_NAME -n $ARGOCD_NS migration-nudge=1 --overwrite
+```
+
+Wait ~30 seconds, then recheck the spoke copy's `destination` again — it should now show a
+`name`-based destination, confirming genuine agent management. Recheck the workload's pod `uid`
+one more time. This has been confirmed safe live, for both `ApplicationSet`-owned and standalone
+apps: the real workload's pod `uid` never changes across this replacement, because you removed
+`syncPolicy.automated` *before* deleting the stale copy — ArgoCD only prunes on delete when
+`automated` (with `prune: true`) is still active.
+
+**That's the whole per-app migration.** No detach step, no other cleanup step — for Case A, the
+same `ApplicationSet` is now the permanent, ongoing manager of the agent-dispatched app, exactly
+like any other agent-mode `ApplicationSet`; for Case B, the `Application` you patched is now a
+normal, permanent agent-dispatched app with no other object managing it. The frozen `ManifestWork`
+from Step 1 is the only leftover either way; leave it in place permanently.
+
+## A standing caution (not specific to migration)
+
+**An immediate post-action check is not proof that a step was safe.** A pod `uid` unchanged one
+second after a risky operation only means nothing had cascaded *yet* — some failure modes (see
+CLAUDE.md → "Designs that were rejected" for a real example) take real wall-clock minutes to
+finish. Re-verify after a wait, not just immediately, at every step above.
+
+**Never delete an `ApplicationSet` whose generated `Application` has an active
+`resources-finalizer.argocd.argoproj.io` while `syncPolicy.automated` is still set** — that
+combination is what deletes the real managed resources. This section is about decommissioning a
+**still-pull-model** app you've decided not to migrate — for decommissioning an app *after* you've
+already migrated it, see the warning further below instead; the procedure is different and simpler.
+To decommission a pull-model app before migrating it, the safe order is:
+1. Remove `syncPolicy.automated` from the `ApplicationSet`'s template first.
+2. Confirm that change reached the live Application (`spec.syncPolicy` no longer has `automated`).
+3. Delete the `ApplicationSet`. Do this *before* touching the Application's finalizer — with the
+   `ApplicationSet` still present, stripping the Application's `finalizers` to `[]` can get
+   silently reverted moments later, and a `kubectl delete --wait=true` right after times out
+   waiting on a finalizer that's already back. Deleting the `ApplicationSet` first is safe here
+   specifically because `automated` was already confirmed off, so there's no prune-on-delete
+   cascade risk.
+4. Only now strip the orphaned Application's `finalizers` to `[]` and delete it directly.
+
+For a **standalone** `Application` (Case B), there's no `ApplicationSet` in the picture, so step 3
+above doesn't apply: remove `syncPolicy.automated` directly on the `Application`, confirm it took,
+then strip `finalizers` to `[]` and delete it directly.
+
+**Decommissioning an app *after* it's already been migrated (agent-routed) is different, and
+force-stripping the finalizer here is actively harmful.** Once Step 4 above is done, the
+`Application`'s destination is real and reachable (via the agent), unlike the fake pull-model
+destination — so ArgoCD's own finalize-then-remove-finalizer flow can actually complete on its own,
+and letting it complete normally is how a delete is *supposed* to relay to the spoke's mirrored
+copy through the agent. If you force-strip the finalizer to `[]` before the delete completes (the
+technique used above for a stuck pull-model app with an unreachable destination), the hub object
+disappears immediately but the relay to the agent never gets a chance to happen at all.
+
+**Even with a normal, non-force-stripped delete, still explicitly verify the spoke's copy is
+actually gone — do not assume the relay completed just because the hub delete did.** Confirmed
+live: for an app that existed before argoCDAgent was ever enabled on its cluster (i.e. any
+migrated pull-model app, since migration is by definition retroactive), the delete-relay to the
+agent is not always reliable, with or without force-stripping — in one observed case the relay
+was rejected outright with `source UID annotation is not found for app: <name>` in the agent's
+logs, leaving the app stuck `Terminating` on the hub until its finalizer was cleared manually; in
+another, a clean `--wait=true` delete completed fully on the hub with no error, yet the spoke's
+mirrored `Application` (and its real workload) was silently left behind regardless. Both cases were
+resolved the same way: check for a leftover copy directly on the spoke and delete it there too if
+one exists:
+
+```bash
+kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n $ARGOCD_NS
+# if found (with no corresponding object left on the hub), it's an orphan -- delete it directly:
+kubectl --kubeconfig $SPOKE_KUBECONFIG delete applications.argoproj.io $APP_NAME -n $ARGOCD_NS --wait=true
+```
+
+An orphaned spoke copy is not just inert leftover clutter — left alone, it keeps actively
+reconciling its resources, and will fight any later, unrelated app that happens to reuse the same
+destination namespace and resource names, with the two copies repeatedly overwriting each other's
+`argocd.argoproj.io/tracking-id` and the affected app flapping `Synced`/`OutOfSync` indefinitely.
+Always verify and clean up the spoke side, every time, for every migrated app you decommission.
+
+## Final verification checklist
+
+```bash
+# 1. Basic pull model is disabled hub-wide and the sweep ran
+kubectl get configmap multicluster-integrations-config -n <namespace> -o jsonpath='{.data.config\.yaml}'
+#    ^ should show pullModel.basic.disabled: true
+
+# 2. Same Application, same uid as before you started
+kubectl get applications.argoproj.io $APP_NAME -n $ARGOCD_NS -o jsonpath='{.metadata.uid}'
+#    ^ compare against the uid you recorded before Step 1 -- must be identical
+
+# 3. It's Synced via the agent on both hub and spoke
+kubectl get applications.argoproj.io $APP_NAME -n $ARGOCD_NS
+kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n $ARGOCD_NS
+
+# 3b. It's Synced via the agent for real, not just coincidentally still Synced from before
+# (see Step 5 -- this is the check that actually distinguishes the two)
+kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n $ARGOCD_NS -o jsonpath='{.spec.destination}'
+#    ^ must show a name-based destination (e.g. "in-cluster") -- NOT server: https://kubernetes.default.svc
+
+# 4. The real workload was never touched
+kubectl --kubeconfig $SPOKE_KUBECONFIG get pods -n <dest-namespace> -o jsonpath='{.items[0].metadata.uid}'
+
+# 5. No duplicate ArgoCD instances fighting
+kubectl --kubeconfig $SPOKE_KUBECONFIG get argocd -n $ARGOCD_NS
+#    ^ should show exactly ONE (the addon-managed acm-openshift-gitops)
+kubectl --kubeconfig $SPOKE_KUBECONFIG get pods -n $ARGOCD_NS
+#    ^ no CrashLoopBackOff / restart-looping pods
+
+# 6. argocd-agent is healthy and has been stable for a while
+kubectl --kubeconfig $SPOKE_KUBECONFIG get pods -n $ARGOCD_NS -l app.kubernetes.io/part-of=argocd-agent
+
+# 7. This app's own ManifestWork is frozen, not enforcing
+kubectl get manifestwork -n $CLUSTER_NAME -o json | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for i in d['items']:
+    ann = i.get('metadata', {}).get('annotations', {}) or {}
+    if ann.get('apps.open-cluster-management.io/hub-application-name') == '$APP_NAME':
+        print(i['metadata']['name'], i['spec']['manifestConfigs'][0]['updateStrategy']['type'])
+"
+#    ^ should show "ReadOnly" -- never "ServerSideApply"/"Update" for this app again
+```
+
+## Re-enabling the basic pull model
+
+If you need to bring the basic pull model back (e.g. rolling back a migration you haven't
+completed yet), set `pullModel.basic.disabled: false` in the ConfigMap and restart the pod again.
+Reconciliation resumes for any app still carrying the pull label/annotations. This does **not**
+automatically revert `ManifestWork`s that were swept to `ReadOnly` back to their prior update
+strategy — if you want a specific app to go back to being pull-model-enforced, patch its
+`ManifestWork`'s `updateStrategy` back explicitly.

--- a/docs/basic-pull-to-argocd-agent-migration.md
+++ b/docs/basic-pull-to-argocd-agent-migration.md
@@ -104,10 +104,42 @@ do not need to repeat it per app or per cluster, and you do not need to manually
    ```
 
    If it doesn't exist, one of the controller's containers will self-create it with defaults the
-   first time it starts — in that case just wait for it to appear, or create it yourself with the
-   content below.
+   first time it starts — either wait for it to appear, or create it yourself directly:
 
-   Set (or add) `pullModel.basic.disabled: true` under the `config.yaml` key:
+   ```bash
+   cat > /tmp/config.yaml <<'EOF'
+   pullModel:
+     basic:
+       disabled: true
+   EOF
+   kubectl create configmap multicluster-integrations-config -n <namespace> \
+     --from-file=config.yaml=/tmp/config.yaml
+   ```
+
+   `--from-file=config.yaml=<path>` stores the file's raw bytes under that key with no shell
+   quoting/escaping involved at all — simpler than the patch form below, and the right choice
+   whenever the ConfigMap doesn't exist yet. If it already exists, `kubectl create` just fails
+   with `AlreadyExists` — fall through to editing it in place instead.
+
+   Set (or add) `pullModel.basic.disabled: true` under the `config.yaml` key on an **existing**
+   ConfigMap. `config.yaml` is a
+   single YAML blob (not flat ConfigMap keys), so a merge patch on `data` replaces the **entire**
+   string — do not just paste a `pullModel`-only patch if the ConfigMap already has other sections
+   under `config.yaml` (current or future). Edit the existing content instead:
+
+   ```bash
+   kubectl get configmap multicluster-integrations-config -n <namespace> -o jsonpath='{.data.config\.yaml}' > /tmp/config.yaml
+   # edit /tmp/config.yaml: add or change pullModel.basic.disabled: true, leaving any other
+   # sections untouched
+   # jq --rawfile safely JSON-encodes the file's content (quotes, backslashes, newlines) --
+   # do not hand-build the JSON string with sed/string interpolation, it will break on any
+   # YAML value containing a quote or backslash.
+   kubectl patch configmap multicluster-integrations-config -n <namespace> --type=merge \
+     -p "$(jq -n --rawfile cfg /tmp/config.yaml '{"data":{"config.yaml":$cfg}}')"
+   ```
+
+   If you know the ConfigMap has no other sections yet (a fresh install), the simpler one-shot form
+   is fine:
 
    ```bash
    kubectl patch configmap multicluster-integrations-config -n <namespace> --type=merge -p '{
@@ -164,10 +196,14 @@ What just happened, at the code level:
   this component from this point on.
 - `gitopssyncresc` (the ACM Search polling loop) and `multiclusterstatusaggregation` (the
   `MulticlusterApplicationSetReport` generator) both skip their periodic work entirely.
-- Every existing pull-model `ManifestWork` had its `applications` manifest config's
-  `updateStrategy` set to `ReadOnly` — this stops the spoke's klusterlet work-agent from
-  re-asserting the delivered `Application` spec, without deleting anything. Health/sync/operation
-  status feedback continues flowing normally; only spec enforcement stops.
+- The sweep is **best-effort, not guaranteed**: each matching `ManifestWork`'s `applications`
+  manifest config gets its `updateStrategy` set to `ReadOnly`, but a failed update (e.g. a
+  resourceVersion conflict) is logged and skipped rather than retried indefinitely — check the log
+  line from step 4 above and the per-`ManifestWork` verification in step 5 below; if any row isn't
+  `ReadOnly`, either fix it directly or rerun the sweep (restart the pod again) before migrating
+  that app. Once genuinely applied, this stops the spoke's klusterlet work-agent from re-asserting
+  the delivered `Application` spec, without deleting anything. Health/sync/operation status
+  feedback continues flowing normally; only spec enforcement stops.
 - None of this touches `pkg/controller/gitopscluster` or anything used by argocd-agent — this is a
   pure basic-pull-model shutoff switch.
 
@@ -205,9 +241,25 @@ expected, not a stuck reconcile):
 kubectl get addondeploymentconfig gitops-addon-config -n $CLUSTER_NAME \
   -o jsonpath='{.spec.customizedVariables[?(@.name=="ARGOCD_AGENT_ENABLED")].value}'
 
-# agent cluster secret appears on the hub
-kubectl get secret cluster-$CLUSTER_NAME -n $ARGOCD_NS \
-  -o jsonpath='{.metadata.labels.argocd-agent\.argoproj-labs\.io/agent-name}'
+# agent cluster secret appears on the hub, correctly labeled AND annotated skip-reconcile: "true"
+# (skip-reconcile is what keeps the hub's own app-controller from fighting the agent for this
+# cluster -- see CLAUDE.md -> "Skip-Reconcile Annotation on Agent Cluster Secrets"). Assert both
+# explicitly rather than just eyeballing the printed value -- proceeding with either one missing
+# means either the agent was never actually wired up, or the hub app-controller will fight the
+# agent for this cluster once Step 4 dispatches to it.
+AGENT_NAME_LABEL=$(kubectl get secret cluster-$CLUSTER_NAME -n $ARGOCD_NS \
+  -o jsonpath='{.metadata.labels.argocd-agent\.argoproj-labs\.io/agent-name}')
+if [ "$AGENT_NAME_LABEL" != "$CLUSTER_NAME" ]; then
+  echo "agent cluster secret is missing its agent-name label (got '$AGENT_NAME_LABEL') -- stop, do not proceed to Step 3/4" >&2
+  exit 1
+fi
+
+SKIP_RECONCILE=$(kubectl get secret cluster-$CLUSTER_NAME -n $ARGOCD_NS \
+  -o jsonpath='{.metadata.annotations.argocd\.argoproj\.io/skip-reconcile}')
+if [ "$SKIP_RECONCILE" != "true" ]; then
+  echo "agent cluster secret is missing skip-reconcile: \"true\" (got '$SKIP_RECONCILE') -- stop, do not proceed to Step 3/4" >&2
+  exit 1
+fi
 ```
 
 ## Step 3 — Resolve a pre-existing, differently-named ArgoCD instance (if any)
@@ -222,14 +274,30 @@ permanently restarting on `"url modified. restarting"`).
 
 ```bash
 kubectl --kubeconfig $SPOKE_KUBECONFIG get argocd -n $ARGOCD_NS
-# if you see both acm-openshift-gitops AND some other name:
+```
+
+**Before deleting the other instance, inventory every `Application` in this namespace** — deleting
+it removes its control-plane, so *every* `Application` it was reconciling (not just the one you're
+migrating) loses that reconciliation, not only the app you're migrating:
+
+```bash
+kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io -n $ARGOCD_NS
+```
+
+For each app in that list other than the one you're migrating, either plan to migrate it too (repeat
+this runbook for it) or explicitly accept that it stops being reconciled once the old instance is
+gone. Do not delete the old ArgoCD CR until you've made a call on every app it lists — an app
+silently losing reconciliation is easy to miss until something drifts.
+
+```bash
+# only once you've accounted for every app the old instance was reconciling:
 kubectl --kubeconfig $SPOKE_KUBECONFIG delete argocd <the-other-name> -n $ARGOCD_NS
 ```
 
-This is safe — deleting an ArgoCD CR does not cascade to the Applications or real workloads it was
-reconciling (they aren't Kubernetes-owned by the ArgoCD CR), only to its own control-plane
-components (application-controller, repo-server, redis, server). Confirm the workload's pod `uid`
-is unchanged before and after.
+This is safe for the workloads themselves — deleting an ArgoCD CR does not cascade to the
+Applications or real workloads it was reconciling (they aren't Kubernetes-owned by the ArgoCD CR),
+only to its own control-plane components (application-controller, repo-server, redis, server).
+Confirm the workload's pod `uid` is unchanged before and after.
 
 Then wait for the agent pod to reach **two consecutive stable `Running` samples**, not just one — a
 crash-looping pod can report `Running` momentarily between restarts:
@@ -324,10 +392,11 @@ spoke's copy does not automatically get replaced, and can keep being reconciled 
 already reconciling it before — which, from the hub's perspective, still reports back as `Synced`,
 even though the agent isn't actually managing anything.
 
-Check the spoke's copy directly:
+Check the spoke's copy directly (`-o json | jq` rather than `-o jsonpath` on the whole object, since
+`jsonpath`'s formatting of a nested object isn't reliably valid JSON across `kubectl` versions):
 
 ```bash
-kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n $ARGOCD_NS -o jsonpath='{.spec.destination}'
+kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n $ARGOCD_NS -o json | jq '.spec.destination'
 ```
 
 - `{"name":"in-cluster", ...}` (or another agent-resolved name) — the agent already has genuine
@@ -336,13 +405,57 @@ kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n
   **not** taken over. The spoke's stale copy needs to be replaced:
 
 ```bash
-# On the SPOKE: remove automated first, so the delete below does not prune the real resources
-kubectl --kubeconfig $SPOKE_KUBECONFIG patch applications.argoproj.io $APP_NAME -n $ARGOCD_NS \
-  --type=json -p='[{"op":"remove","path":"/spec/syncPolicy/automated"}]'
+set -e   # fail closed: stop at the first error rather than risk deleting under an unverified state
 
-# On the SPOKE: strip the finalizer and delete the stale copy directly
+# On the SPOKE: remove automated first, so the delete below does not prune the real resources.
+# A merge patch setting it to null is idempotent -- unlike a JSON-patch "remove", it does not
+# error if automated is already absent (e.g. you're re-running this after a partial attempt).
 kubectl --kubeconfig $SPOKE_KUBECONFIG patch applications.argoproj.io $APP_NAME -n $ARGOCD_NS \
-  --type=merge -p '{"metadata":{"finalizers":[]}}'
+  --type=merge -p '{"spec":{"syncPolicy":{"automated":null}}}'
+
+# On the SPOKE: remove ONLY the ArgoCD finalizer -- preserve any other, unrelated finalizer the
+# object might carry, rather than blindly clearing the whole list. Make this patch conditional on
+# the resourceVersion we just read: including metadata.resourceVersion in a merge-patch body is a
+# genuine, server-enforced precondition -- unlike the finalizer list itself, resourceVersion is
+# never merged, so if the object changed since our read (e.g. something re-added the finalizer
+# concurrently) the API server rejects the whole patch with a 409 Conflict instead of silently
+# clobbering whatever is there. This is a real optimistic-concurrency check, not just an
+# application-level read-then-act race (confirmed live: a merge patch carrying a stale
+# resourceVersion is rejected with "Operation cannot be fulfilled ... the object has been
+# modified").
+CURRENT=$(kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n $ARGOCD_NS -o json)
+CURRENT_RV=$(echo "$CURRENT" | jq -r '.metadata.resourceVersion')
+NEW_FINALIZERS=$(echo "$CURRENT" | jq -c '[.metadata.finalizers[]? | select(. != "resources-finalizer.argocd.argoproj.io")]')
+PATCHED=$(kubectl --kubeconfig $SPOKE_KUBECONFIG patch applications.argoproj.io $APP_NAME -n $ARGOCD_NS \
+  --type=merge -o json -p "{\"metadata\":{\"resourceVersion\":\"$CURRENT_RV\",\"finalizers\":$NEW_FINALIZERS}}") || {
+  echo "finalizer-removal patch was rejected (object changed since our read) -- stop, re-verify before retrying" >&2
+  exit 1
+}
+
+# The patch response above IS the server's confirmed post-patch state -- no separate read-back is
+# needed to check the finalizer list, since the conditional patch already proves nothing else
+# touched the object between our read and this write. Only something reconciling in the instant
+# AFTER our patch succeeded could still re-add a finalizer, which the delete-time check below
+# catches.
+REMAINING=$(echo "$PATCHED" | jq -c '.metadata.finalizers // []')
+if [ "$REMAINING" != "[]" ]; then
+  echo "finalizer(s) still present after patch ($REMAINING) -- stop, do not delete, investigate before retrying" >&2
+  exit 1
+fi
+
+# kubectl delete has no resourceVersion precondition flag at all -- "the delete command does NOT
+# do resource version checks" (kubectl delete --help, verified against a live cluster). This
+# immediate re-check right before deleting is the closest practical equivalent: abort if the
+# object changed again in the (now much smaller) window between our just-confirmed atomic patch
+# above and this delete call, rather than deleting an object we no longer have a verified-clean
+# view of.
+RESOURCE_VERSION=$(echo "$PATCHED" | jq -r '.metadata.resourceVersion')
+CURRENT_RESOURCE_VERSION=$(kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n $ARGOCD_NS \
+  -o jsonpath='{.metadata.resourceVersion}')
+if [ "$CURRENT_RESOURCE_VERSION" != "$RESOURCE_VERSION" ]; then
+  echo "object changed (resourceVersion $RESOURCE_VERSION -> $CURRENT_RESOURCE_VERSION) since the patch -- stop, re-verify before retrying" >&2
+  exit 1
+fi
 kubectl --kubeconfig $SPOKE_KUBECONFIG delete applications.argoproj.io $APP_NAME -n $ARGOCD_NS --wait=true
 
 # Confirm the real workload survived this (pod uid unchanged from what you recorded earlier)
@@ -443,7 +556,7 @@ kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n
 
 # 3b. It's Synced via the agent for real, not just coincidentally still Synced from before
 # (see Step 5 -- this is the check that actually distinguishes the two)
-kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n $ARGOCD_NS -o jsonpath='{.spec.destination}'
+kubectl --kubeconfig $SPOKE_KUBECONFIG get applications.argoproj.io $APP_NAME -n $ARGOCD_NS -o json | jq '.spec.destination'
 #    ^ must show a name-based destination (e.g. "in-cluster") -- NOT server: https://kubernetes.default.svc
 
 # 4. The real workload was never touched
@@ -464,10 +577,16 @@ import json, sys
 d = json.load(sys.stdin)
 for i in d['items']:
     ann = i.get('metadata', {}).get('annotations', {}) or {}
-    if ann.get('apps.open-cluster-management.io/hub-application-name') == '$APP_NAME':
-        print(i['metadata']['name'], i['spec']['manifestConfigs'][0]['updateStrategy']['type'])
+    if ann.get('apps.open-cluster-management.io/hub-application-name') != '$APP_NAME':
+        continue
+    for mc in i['spec'].get('manifestConfigs', []):
+        ri = mc.get('resourceIdentifier', {})
+        if ri.get('group') == 'argoproj.io' and ri.get('resource') == 'applications':
+            print(i['metadata']['name'], (mc.get('updateStrategy') or {}).get('type'))
 "
-#    ^ should show "ReadOnly" -- never "ServerSideApply"/"Update" for this app again
+#    ^ should show "ReadOnly" -- never "ServerSideApply"/"Update" for this app again -- match by
+#    resourceIdentifier, not position: a ManifestWork can carry other manifestConfigs entries
+#    (e.g. a Namespace) ahead of the applications one
 ```
 
 ## Re-enabling the basic pull model

--- a/pkg/controller/gitopssyncresc/gitopssyncresc_controller.go
+++ b/pkg/controller/gitopssyncresc/gitopssyncresc_controller.go
@@ -99,7 +99,12 @@ func (c *HTTPDataSender) Send(httpClient *http.Client, req *http.Request) (map[s
 }
 
 type GitOpsSyncResource struct {
-	Client             client.Client
+	Client client.Client
+	// ConfigClient is a direct, uncached client used only for the per-tick pull-model-disabled
+	// check in Start() -- Client above is the manager's regular (cached) client, and this
+	// controller's manager does not override its default client to be non-caching, so reusing
+	// Client there would read a potentially-stale informer cache instead of the live ConfigMap.
+	ConfigClient       client.Client
 	Interval           int
 	ResourceDir        string
 	SearchBatchSize    int
@@ -119,13 +124,18 @@ func Add(mgr manager.Manager, interval int, resourceDir string, searchBatchSize 
 	}
 
 	// Add() runs before mgr.Start(), so mgr.GetClient() (a cached client here) isn't usable
-	// yet -- use a direct, uncached client for this one-time startup read/create.
+	// yet -- use a direct, uncached client for this one-time startup read/create, and for the
+	// per-tick disabled check in Start() below (this manager's default client stays cached
+	// even after Start(), unlike propagation's and multiclusterstatusaggregation's).
 	directClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to construct direct client for pull-model config: %w", err)
 	}
 
-	pullModelCfg, err := pullmodelconfig.LoadOrCreate(context.TODO(), directClient)
+	bootstrapCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pullModelCfg, err := pullmodelconfig.LoadOrCreate(bootstrapCtx, directClient)
 	if err != nil {
 		klog.Errorf("unable to load multicluster-integrations-config, defaulting to basic pull model enabled: %v", err)
 		pullModelCfg = &pullmodelconfig.ControllerConfig{}
@@ -137,6 +147,7 @@ func Add(mgr manager.Manager, interval int, resourceDir string, searchBatchSize 
 
 	gitopsSyncResc := &GitOpsSyncResource{
 		Client:             mgr.GetClient(),
+		ConfigClient:       directClient,
 		Interval:           interval,
 		ResourceDir:        resourceDir,
 		SearchBatchSize:    searchBatchSize,
@@ -163,7 +174,15 @@ func (r *GitOpsSyncResource) Start(ctx context.Context) error {
 		// Checked fresh on every tick, not cached at startup: a Deployment rolling restart can
 		// briefly run the old (not-yet-disabled) pod alongside the new (disabled) one, and a
 		// cached flag would let that old pod's next tick run anyway. See pkg/pullmodelconfig.
-		if cfg, err := pullmodelconfig.LoadOrCreate(ctx, r.Client); err == nil && cfg.PullModel.Basic.Disabled {
+		// Uses ConfigClient (uncached), not Client -- this manager's default client stays a
+		// cached informer-backed client even after Start(), which would otherwise read a
+		// potentially-stale view of the ConfigMap instead of the live value.
+		loadCtx, cancel := context.WithTimeout(ctx, pullmodelconfig.LoadTimeout)
+		defer cancel()
+
+		if cfg, err := pullmodelconfig.LoadOrCreate(loadCtx, r.ConfigClient); err != nil {
+			klog.Errorf("unable to load multicluster-integrations-config, proceeding as if basic pull model is enabled: %v", err)
+		} else if cfg.PullModel.Basic.Disabled {
 			return
 		}
 

--- a/pkg/controller/gitopssyncresc/gitopssyncresc_controller.go
+++ b/pkg/controller/gitopssyncresc/gitopssyncresc_controller.go
@@ -47,6 +47,7 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	gitopsclusterV1beta1 "open-cluster-management.io/multicloud-integrations/pkg/apis/apps/v1beta1"
 	appsetreport "open-cluster-management.io/multicloud-integrations/pkg/apis/appsetreport/v1alpha1"
+	"open-cluster-management.io/multicloud-integrations/pkg/pullmodelconfig"
 )
 
 const (
@@ -117,6 +118,23 @@ func Add(mgr manager.Manager, interval int, resourceDir string, searchBatchSize 
 		token = mgr.GetConfig().BearerToken
 	}
 
+	// Add() runs before mgr.Start(), so mgr.GetClient() (a cached client here) isn't usable
+	// yet -- use a direct, uncached client for this one-time startup read/create.
+	directClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
+	if err != nil {
+		return err
+	}
+
+	pullModelCfg, err := pullmodelconfig.LoadOrCreate(context.TODO(), directClient)
+	if err != nil {
+		klog.Errorf("unable to load multicluster-integrations-config, defaulting to basic pull model enabled: %v", err)
+		pullModelCfg = &pullmodelconfig.ControllerConfig{}
+	}
+
+	if pullModelCfg.PullModel.Basic.Disabled {
+		klog.Info("basic pull model is disabled via multicluster-integrations-config; search sync will not run")
+	}
+
 	gitopsSyncResc := &GitOpsSyncResource{
 		Client:             mgr.GetClient(),
 		Interval:           interval,
@@ -128,7 +146,7 @@ func Add(mgr manager.Manager, interval int, resourceDir string, searchBatchSize 
 	}
 
 	// Create resourceDir if it does not exist
-	_, err := os.Stat(resourceDir)
+	_, err = os.Stat(resourceDir)
 	if err != nil && os.IsNotExist(err) {
 		err = os.MkdirAll(resourceDir, 0750)
 		if err != nil {
@@ -142,6 +160,13 @@ func Add(mgr manager.Manager, interval int, resourceDir string, searchBatchSize 
 
 func (r *GitOpsSyncResource) Start(ctx context.Context) error {
 	go wait.Until(func() {
+		// Checked fresh on every tick, not cached at startup: a Deployment rolling restart can
+		// briefly run the old (not-yet-disabled) pod alongside the new (disabled) one, and a
+		// cached flag would let that old pod's next tick run anyway. See pkg/pullmodelconfig.
+		if cfg, err := pullmodelconfig.LoadOrCreate(ctx, r.Client); err == nil && cfg.PullModel.Basic.Disabled {
+			return
+		}
+
 		err := r.syncResources()
 		if err != nil {
 			klog.Error("error syncing resources from search", err)

--- a/pkg/controller/multiclusterstatusaggregation/multiclusterStatusAggregation_controller.go
+++ b/pkg/controller/multiclusterstatusaggregation/multiclusterStatusAggregation_controller.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/klog"
 	workv1 "open-cluster-management.io/api/work/v1"
 	appsetreportV1alpha1 "open-cluster-management.io/multicloud-integrations/pkg/apis/appsetreport/v1alpha1"
+	"open-cluster-management.io/multicloud-integrations/pkg/pullmodelconfig"
 	propagation "open-cluster-management.io/multicloud-integrations/propagation-controller/application"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -91,6 +92,19 @@ func (a AppSetClusterConditionsSorter) Swap(i, j int)      { a[i], a[j] = a[j], 
 func (a AppSetClusterConditionsSorter) Less(i, j int) bool { return a[i].Cluster < a[j].Cluster }
 
 func Add(mgr manager.Manager, interval int, resourceDir string) error {
+	// This manager's GetClient() is already a non-caching, direct client (see
+	// NewNonCachingClient in cmd/multiclusterstatusaggregation/exec/manager.go), so it's
+	// safe to use here even though Add() runs before mgr.Start().
+	pullModelCfg, err := pullmodelconfig.LoadOrCreate(context.TODO(), mgr.GetClient())
+	if err != nil {
+		klog.Errorf("unable to load multicluster-integrations-config, defaulting to basic pull model enabled: %v", err)
+		pullModelCfg = &pullmodelconfig.ControllerConfig{}
+	}
+
+	if pullModelCfg.PullModel.Basic.Disabled {
+		klog.Info("basic pull model is disabled via multicluster-integrations-config; status aggregation will not run")
+	}
+
 	dsRS := &ReconcilePullModelAggregation{
 		Client:      mgr.GetClient(),
 		Interval:    interval,
@@ -102,6 +116,13 @@ func Add(mgr manager.Manager, interval int, resourceDir string) error {
 
 func (r *ReconcilePullModelAggregation) Start(ctx context.Context) error {
 	go wait.Until(func() {
+		// Checked fresh on every tick, not cached at startup: a Deployment rolling restart can
+		// briefly run the old (not-yet-disabled) pod alongside the new (disabled) one, and a
+		// cached flag would let that old pod's next tick run anyway. See pkg/pullmodelconfig.
+		if cfg, err := pullmodelconfig.LoadOrCreate(ctx, r.Client); err == nil && cfg.PullModel.Basic.Disabled {
+			return
+		}
+
 		r.houseKeeping()
 	}, time.Duration(r.Interval)*time.Second, ctx.Done())
 

--- a/pkg/controller/multiclusterstatusaggregation/multiclusterStatusAggregation_controller.go
+++ b/pkg/controller/multiclusterstatusaggregation/multiclusterStatusAggregation_controller.go
@@ -119,7 +119,12 @@ func (r *ReconcilePullModelAggregation) Start(ctx context.Context) error {
 		// Checked fresh on every tick, not cached at startup: a Deployment rolling restart can
 		// briefly run the old (not-yet-disabled) pod alongside the new (disabled) one, and a
 		// cached flag would let that old pod's next tick run anyway. See pkg/pullmodelconfig.
-		if cfg, err := pullmodelconfig.LoadOrCreate(ctx, r.Client); err == nil && cfg.PullModel.Basic.Disabled {
+		loadCtx, cancel := context.WithTimeout(ctx, pullmodelconfig.LoadTimeout)
+		defer cancel()
+
+		if cfg, err := pullmodelconfig.LoadOrCreate(loadCtx, r.Client); err != nil {
+			klog.Errorf("unable to load multicluster-integrations-config, proceeding as if basic pull model is enabled: %v", err)
+		} else if cfg.PullModel.Basic.Disabled {
 			return
 		}
 

--- a/pkg/pullmodelconfig/config.go
+++ b/pkg/pullmodelconfig/config.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -46,6 +47,13 @@ const (
 
 	podNamespaceEnvVar          = "POD_NAMESPACE"
 	serviceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+	// LoadTimeout bounds a single LoadOrCreate call. Per-reconcile/per-tick callers should derive
+	// a child context via context.WithTimeout(ctx, pullmodelconfig.LoadTimeout) before calling
+	// LoadOrCreate, so a slow or unresponsive API server can't block that reconcile/tick
+	// indefinitely -- the ambient ctx passed in from controller-runtime (or a periodic loop's
+	// process-lifetime ctx) otherwise carries no deadline of its own.
+	LoadTimeout = 10 * time.Second
 )
 
 // ControllerConfig is the top-level shape of the multicluster-integrations-config ConfigMap.
@@ -111,7 +119,7 @@ func ResolveNamespace() (string, error) {
 func LoadOrCreate(ctx context.Context, c client.Client) (*ControllerConfig, error) {
 	ns, err := ResolveNamespace()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("LoadOrCreate: %w", err)
 	}
 
 	cm := &corev1.ConfigMap{}
@@ -123,7 +131,7 @@ func LoadOrCreate(ctx context.Context, c client.Client) (*ControllerConfig, erro
 	case apierrors.IsNotFound(err):
 		return createDefault(ctx, c, ns)
 	default:
-		return nil, err
+		return nil, fmt.Errorf("failed to get %s/%s: %w", ns, ConfigMapName, err)
 	}
 }
 

--- a/pkg/pullmodelconfig/config.go
+++ b/pkg/pullmodelconfig/config.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package pullmodelconfig loads the multicluster-integrations-config ConfigMap read by the
+// propagation, gitopssyncresc, and multiclusterstatusaggregation binaries at startup. It is
+// deliberately independent of pkg/controller/gitopscluster (the argocd-agent controller) --
+// nothing here is imported by, or imports, that package.
+package pullmodelconfig
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	// ConfigMapName is the fixed name of the shared config ConfigMap. It always lives in
+	// whatever namespace the reading pod itself is running in -- see ResolveNamespace --
+	// never a hardcoded namespace, since that can differ across installs.
+	ConfigMapName = "multicluster-integrations-config"
+
+	// ConfigMapDataKey is the single data key holding the YAML-serialized ControllerConfig.
+	// A single structured blob (rather than flat ConfigMap data entries) so future settings
+	// that need nesting or lists don't require a schema rework.
+	ConfigMapDataKey = "config.yaml"
+
+	podNamespaceEnvVar          = "POD_NAMESPACE"
+	serviceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+)
+
+// ControllerConfig is the top-level shape of the multicluster-integrations-config ConfigMap.
+// Unknown fields are ignored on read (forward compatible with future additions); fields
+// absent from an older or hand-edited ConfigMap default to their Go zero value (backward
+// compatible -- an empty or partial ConfigMap is never an error).
+type ControllerConfig struct {
+	PullModel PullModelConfig `json:"pullModel,omitempty"`
+	// Future sibling sections go here, e.g.:
+	// SomeOtherFeature SomeOtherFeatureConfig `json:"someOtherFeature,omitempty"`
+}
+
+// PullModelConfig groups settings for the different pull-model delivery mechanisms this
+// repo supports. Named as a section (not a bare top-level bool) specifically so it reads
+// unambiguously next to argocd-agent, which is also pull-based in its own agent-to-principal
+// communication but is a completely different mechanism from what's configured here.
+type PullModelConfig struct {
+	// Basic controls the classic ManifestWork-based pull model (propagation-controller,
+	// gitopssyncresc, multiclusterstatusaggregation).
+	Basic BasicPullModelConfig `json:"basic,omitempty"`
+	// Future sibling, if the opt-in Maestro-backed variant ever needs the same switch:
+	// Maestro MaestroPullModelConfig `json:"maestro,omitempty"`
+}
+
+// BasicPullModelConfig controls the classic ManifestWork-based pull model.
+type BasicPullModelConfig struct {
+	// Disabled stops all three basic-pull-model components from doing their normal work:
+	// propagation stops generating/updating ManifestWork (and performs a one-time sweep of
+	// existing ManifestWork to ReadOnly on startup while this is true), gitopssyncresc stops
+	// polling the search API, and multiclusterstatusaggregation stops building
+	// MulticlusterApplicationSetReports. The processes keep running either way -- this does
+	// not scale anything down, it just makes their reconcile/sync loops no-op.
+	Disabled bool `json:"disabled,omitempty"`
+}
+
+// ResolveNamespace returns the namespace the current process is running in, without ever
+// assuming a hardcoded value (the multicluster-integrations deployment's namespace is not
+// guaranteed to be the same across every install). It checks the POD_NAMESPACE env var
+// first -- already set on these containers today via the Downward API -- and falls back to
+// the namespace file Kubernetes automatically mounts into every pod that has a service
+// account, which requires no Deployment change at all.
+func ResolveNamespace() (string, error) {
+	if ns := os.Getenv(podNamespaceEnvVar); ns != "" {
+		return ns, nil
+	}
+
+	data, err := os.ReadFile(serviceAccountNamespaceFile)
+	if err != nil {
+		return "", fmt.Errorf("unable to resolve current namespace: %s is not set and %s could not be read: %w",
+			podNamespaceEnvVar, serviceAccountNamespaceFile, err)
+	}
+
+	return string(data), nil
+}
+
+// LoadOrCreate reads the multicluster-integrations-config ConfigMap from the current pod's
+// own namespace (see ResolveNamespace). If it does not exist, it is created with all
+// defaults (pullModel.basic.disabled: false) so a fresh install never needs to "find" a
+// config that was never provisioned -- whichever of the three sibling binaries starts first
+// plants it. Safe to call concurrently from multiple sibling containers in the same pod: if
+// two processes race to create it, the loser's Create fails with AlreadyExists and it simply
+// re-Gets whatever the winner wrote, rather than erroring out.
+func LoadOrCreate(ctx context.Context, c client.Client) (*ControllerConfig, error) {
+	ns, err := ResolveNamespace()
+	if err != nil {
+		return nil, err
+	}
+
+	cm := &corev1.ConfigMap{}
+	err = c.Get(ctx, types.NamespacedName{Name: ConfigMapName, Namespace: ns}, cm)
+
+	switch {
+	case err == nil:
+		return parse(cm)
+	case apierrors.IsNotFound(err):
+		return createDefault(ctx, c, ns)
+	default:
+		return nil, err
+	}
+}
+
+func createDefault(ctx context.Context, c client.Client, ns string) (*ControllerConfig, error) {
+	defaultCfg := &ControllerConfig{}
+
+	raw, err := yaml.Marshal(defaultCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal default pull model config: %w", err)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ConfigMapName,
+			Namespace: ns,
+		},
+		Data: map[string]string{
+			ConfigMapDataKey: string(raw),
+		},
+	}
+
+	if err := c.Create(ctx, cm); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			existing := &corev1.ConfigMap{}
+			if getErr := c.Get(ctx, types.NamespacedName{Name: ConfigMapName, Namespace: ns}, existing); getErr != nil {
+				return nil, fmt.Errorf("lost create race for %s/%s but could not re-read it: %w", ns, ConfigMapName, getErr)
+			}
+
+			return parse(existing)
+		}
+
+		return nil, fmt.Errorf("failed to create %s/%s: %w", ns, ConfigMapName, err)
+	}
+
+	return defaultCfg, nil
+}
+
+func parse(cm *corev1.ConfigMap) (*ControllerConfig, error) {
+	cfg := &ControllerConfig{}
+
+	raw, ok := cm.Data[ConfigMapDataKey]
+	if !ok {
+		// Key missing from an otherwise-present ConfigMap -- treat as all-defaults
+		// rather than an error, same backward-compatible spirit as the ConfigMap
+		// being absent entirely.
+		return cfg, nil
+	}
+
+	if err := yaml.Unmarshal([]byte(raw), cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse %s/%s data[%s]: %w", cm.Namespace, cm.Name, ConfigMapDataKey, err)
+	}
+
+	return cfg, nil
+}

--- a/pkg/pullmodelconfig/config_test.go
+++ b/pkg/pullmodelconfig/config_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pullmodelconfig
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("failed to build test scheme: %v", err)
+	}
+
+	return s
+}
+
+func objMeta(name, namespace string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{Name: name, Namespace: namespace}
+}
+
+func TestResolveNamespace_EnvVar(t *testing.T) {
+	t.Setenv(podNamespaceEnvVar, "some-namespace")
+
+	ns, err := ResolveNamespace()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ns != "some-namespace" {
+		t.Fatalf("expected 'some-namespace', got %q", ns)
+	}
+}
+
+func TestResolveNamespace_FallbackFile(t *testing.T) {
+	t.Setenv(podNamespaceEnvVar, "")
+
+	// Can't easily override the hardcoded service account file path without touching
+	// production code, so just confirm the error path is sane when neither is available
+	// (this test environment has no POD_NAMESPACE and, almost certainly, no mounted
+	// service account namespace file).
+	if _, err := os.Stat(serviceAccountNamespaceFile); err == nil {
+		t.Skip("service account namespace file exists in this environment, skipping negative-path check")
+	}
+
+	_, err := ResolveNamespace()
+	if err == nil {
+		t.Fatal("expected an error when neither POD_NAMESPACE nor the service account file are available")
+	}
+}
+
+func TestLoadOrCreate_CreatesDefaultWhenMissing(t *testing.T) {
+	t.Setenv(podNamespaceEnvVar, "test-ns")
+
+	scheme := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	cfg, err := LoadOrCreate(context.Background(), c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.PullModel.Basic.Disabled {
+		t.Fatal("expected default config to have basic pull model NOT disabled")
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: ConfigMapName, Namespace: "test-ns"}, cm); err != nil {
+		t.Fatalf("expected ConfigMap to have been created: %v", err)
+	}
+
+	if _, ok := cm.Data[ConfigMapDataKey]; !ok {
+		t.Fatalf("expected created ConfigMap to have data key %q", ConfigMapDataKey)
+	}
+}
+
+func TestLoadOrCreate_ReadsExisting(t *testing.T) {
+	t.Setenv(podNamespaceEnvVar, "test-ns")
+
+	scheme := newTestScheme(t)
+	existing := &corev1.ConfigMap{
+		ObjectMeta: objMeta(ConfigMapName, "test-ns"),
+		Data: map[string]string{
+			ConfigMapDataKey: "pullModel:\n  basic:\n    disabled: true\n",
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+	cfg, err := LoadOrCreate(context.Background(), c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !cfg.PullModel.Basic.Disabled {
+		t.Fatal("expected existing config's disabled:true to be honored")
+	}
+}
+
+func TestLoadOrCreate_MissingDataKeyDefaultsGracefully(t *testing.T) {
+	t.Setenv(podNamespaceEnvVar, "test-ns")
+
+	scheme := newTestScheme(t)
+	existing := &corev1.ConfigMap{
+		ObjectMeta: objMeta(ConfigMapName, "test-ns"),
+		Data:       map[string]string{},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+	cfg, err := LoadOrCreate(context.Background(), c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.PullModel.Basic.Disabled {
+		t.Fatal("expected missing data key to default to not-disabled")
+	}
+}
+
+func TestLoadOrCreate_MalformedYAMLErrors(t *testing.T) {
+	t.Setenv(podNamespaceEnvVar, "test-ns")
+
+	scheme := newTestScheme(t)
+	existing := &corev1.ConfigMap{
+		ObjectMeta: objMeta(ConfigMapName, "test-ns"),
+		Data: map[string]string{
+			ConfigMapDataKey: "not: [valid: yaml",
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+	if _, err := LoadOrCreate(context.Background(), c); err == nil {
+		t.Fatal("expected an error for malformed YAML")
+	}
+}

--- a/pkg/pullmodelconfig/config_test.go
+++ b/pkg/pullmodelconfig/config_test.go
@@ -141,6 +141,30 @@ func TestLoadOrCreate_MissingDataKeyDefaultsGracefully(t *testing.T) {
 	}
 }
 
+func TestCreateDefault_AlreadyExistsReturnsWinnersConfig(t *testing.T) {
+	// Simulates the race two sibling containers in the same pod can hit: this call loses the
+	// Create race because another container already won it and wrote a non-default config.
+	// createDefault must not error out or overwrite the winner -- it should just re-Get and
+	// return whatever the winner actually wrote.
+	scheme := newTestScheme(t)
+	winner := &corev1.ConfigMap{
+		ObjectMeta: objMeta(ConfigMapName, "test-ns"),
+		Data: map[string]string{
+			ConfigMapDataKey: "pullModel:\n  basic:\n    disabled: true\n",
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(winner).Build()
+
+	cfg, err := createDefault(context.Background(), c, "test-ns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !cfg.PullModel.Basic.Disabled {
+		t.Fatal("expected the AlreadyExists race loser to return the winner's disabled:true config, not overwrite it with defaults")
+	}
+}
+
 func TestLoadOrCreate_MalformedYAMLErrors(t *testing.T) {
 	t.Setenv(podNamespaceEnvVar, "test-ns")
 

--- a/propagation-controller/application/application_controller.go
+++ b/propagation-controller/application/application_controller.go
@@ -38,6 +38,7 @@ import (
 
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	workv1 "open-cluster-management.io/api/work/v1"
+	"open-cluster-management.io/multicloud-integrations/pkg/pullmodelconfig"
 	"open-cluster-management.io/multicloud-integrations/pkg/utils"
 )
 
@@ -171,7 +172,7 @@ func (r *ApplicationReconciler) discoverAndFetchAppProject(application *unstruct
 	// 2. Fall back to trying common ArgoCD namespaces
 	candidateNamespaces := []string{
 		application.GetNamespace(), // Try application's namespace first
-		utils.GitOpsNamespace,         // Default OpenShift GitOps namespace
+		utils.GitOpsNamespace,      // Default OpenShift GitOps namespace
 		"argocd",                   // Common ArgoCD namespace
 	}
 
@@ -380,6 +381,15 @@ func (r *ApplicationReconciler) generateManifestWork(name, namespace string, app
 
 // Reconcile create/update/delete ManifestWork with the Application as its payload
 func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// Checked fresh on every reconcile, not cached at startup: a Deployment rolling restart can
+	// briefly run the old (not-yet-disabled) pod alongside the new (disabled, already-swept) one,
+	// and a cached flag would let that old pod's in-flight reconcile re-create a ManifestWork the
+	// new pod's sweep had just frozen. A live read closes that window regardless of which pod
+	// processes the event. See pkg/pullmodelconfig.
+	if cfg, err := pullmodelconfig.LoadOrCreate(ctx, r.Client); err == nil && cfg.PullModel.Basic.Disabled {
+		return ctrl.Result{}, nil
+	}
+
 	log := log.FromContext(ctx)
 	log.Info("reconciling Application...")
 

--- a/propagation-controller/application/application_controller.go
+++ b/propagation-controller/application/application_controller.go
@@ -386,11 +386,17 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// and a cached flag would let that old pod's in-flight reconcile re-create a ManifestWork the
 	// new pod's sweep had just frozen. A live read closes that window regardless of which pod
 	// processes the event. See pkg/pullmodelconfig.
-	if cfg, err := pullmodelconfig.LoadOrCreate(ctx, r.Client); err == nil && cfg.PullModel.Basic.Disabled {
+	log := log.FromContext(ctx)
+
+	loadCtx, cancel := context.WithTimeout(ctx, pullmodelconfig.LoadTimeout)
+	defer cancel()
+
+	if cfg, err := pullmodelconfig.LoadOrCreate(loadCtx, r.Client); err != nil {
+		log.Error(err, "unable to load multicluster-integrations-config, proceeding as if basic pull model is enabled")
+	} else if cfg.PullModel.Basic.Disabled {
 		return ctrl.Result{}, nil
 	}
 
-	log := log.FromContext(ctx)
 	log.Info("reconciling Application...")
 
 	application := &unstructured.Unstructured{}

--- a/propagation-controller/application/application_status_controller.go
+++ b/propagation-controller/application/application_status_controller.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	appsetreportV1alpha1 "open-cluster-management.io/multicloud-integrations/pkg/apis/appsetreport/v1alpha1"
+	"open-cluster-management.io/multicloud-integrations/pkg/pullmodelconfig"
 )
 
 // ApplicationStatusReconciler reconciles a Application object
@@ -55,6 +56,12 @@ func (re *ApplicationStatusReconciler) SetupWithManager(mgr ctrl.Manager) error 
 
 // Reconcile populates the Application status based on the MulticlusterApplicationSetReport
 func (r *ApplicationStatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// Checked fresh on every reconcile -- see the matching comment in application_controller.go's
+	// Reconcile for why this can't be a flag cached once at startup.
+	if cfg, err := pullmodelconfig.LoadOrCreate(ctx, r.Client); err == nil && cfg.PullModel.Basic.Disabled {
+		return ctrl.Result{}, nil
+	}
+
 	log := log.FromContext(ctx)
 	log.Info("reconciling Application for status update..")
 	defer log.Info("done reconciling Application for status update")

--- a/propagation-controller/application/application_status_controller.go
+++ b/propagation-controller/application/application_status_controller.go
@@ -56,13 +56,19 @@ func (re *ApplicationStatusReconciler) SetupWithManager(mgr ctrl.Manager) error 
 
 // Reconcile populates the Application status based on the MulticlusterApplicationSetReport
 func (r *ApplicationStatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+
 	// Checked fresh on every reconcile -- see the matching comment in application_controller.go's
 	// Reconcile for why this can't be a flag cached once at startup.
-	if cfg, err := pullmodelconfig.LoadOrCreate(ctx, r.Client); err == nil && cfg.PullModel.Basic.Disabled {
+	loadCtx, cancel := context.WithTimeout(ctx, pullmodelconfig.LoadTimeout)
+	defer cancel()
+
+	if cfg, err := pullmodelconfig.LoadOrCreate(loadCtx, r.Client); err != nil {
+		log.Error(err, "unable to load multicluster-integrations-config, proceeding as if basic pull model is enabled")
+	} else if cfg.PullModel.Basic.Disabled {
 		return ctrl.Result{}, nil
 	}
 
-	log := log.FromContext(ctx)
 	log.Info("reconciling Application for status update..")
 	defer log.Info("done reconciling Application for status update")
 

--- a/propagation-controller/application/pull_model_disable.go
+++ b/propagation-controller/application/pull_model_disable.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -66,28 +67,31 @@ func SweepManifestWorksToReadOnly(ctx context.Context, c client.Client) error {
 			continue
 		}
 
-		changed := false
-
-		for j := range mw.Spec.ManifestConfigs {
-			mc := &mw.Spec.ManifestConfigs[j]
-			if mc.ResourceIdentifier.Group != "argoproj.io" || mc.ResourceIdentifier.Resource != "applications" {
-				continue
-			}
-
-			if mc.UpdateStrategy != nil && mc.UpdateStrategy.Type == workv1.UpdateStrategyTypeReadOnly {
-				continue
-			}
-
-			mc.UpdateStrategy = &workv1.UpdateStrategy{Type: workv1.UpdateStrategyTypeReadOnly}
-			changed = true
-		}
-
-		if !changed {
+		if !needsReadOnly(mw) {
 			alreadyDone++
 			continue
 		}
 
-		if err := c.Update(ctx, mw); err != nil {
+		key := client.ObjectKeyFromObject(mw)
+
+		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			// Re-fetch on every attempt (including the first) so a resourceVersion conflict
+			// from a concurrent update (e.g. status feedback from the work-agent) is retried
+			// against the latest object, not the same stale copy that just failed.
+			fresh := &workv1.ManifestWork{}
+			if getErr := c.Get(ctx, key, fresh); getErr != nil {
+				return fmt.Errorf("failed to get ManifestWork %s for pull-model disable sweep: %w", key, getErr)
+			}
+
+			if !needsReadOnly(fresh) {
+				return nil
+			}
+
+			setReadOnly(fresh)
+
+			return c.Update(ctx, fresh)
+		})
+		if err != nil {
 			klog.Errorf("pull-model disable sweep: failed to patch ManifestWork %s/%s to ReadOnly: %v", mw.Namespace, mw.Name, err)
 			continue
 		}
@@ -100,6 +104,36 @@ func SweepManifestWorksToReadOnly(ctx context.Context, c client.Client) error {
 		swept, alreadyDone, skipped)
 
 	return nil
+}
+
+// needsReadOnly reports whether mw's applications manifestConfigs entry (matched by
+// resourceIdentifier, never by position) is not yet updateStrategy=ReadOnly.
+func needsReadOnly(mw *workv1.ManifestWork) bool {
+	for i := range mw.Spec.ManifestConfigs {
+		mc := &mw.Spec.ManifestConfigs[i]
+		if mc.ResourceIdentifier.Group != "argoproj.io" || mc.ResourceIdentifier.Resource != "applications" {
+			continue
+		}
+
+		if mc.UpdateStrategy == nil || mc.UpdateStrategy.Type != workv1.UpdateStrategyTypeReadOnly {
+			return true
+		}
+	}
+
+	return false
+}
+
+// setReadOnly sets updateStrategy=ReadOnly on mw's applications manifestConfigs entry
+// (matched by resourceIdentifier, never by position), leaving every other entry untouched.
+func setReadOnly(mw *workv1.ManifestWork) {
+	for i := range mw.Spec.ManifestConfigs {
+		mc := &mw.Spec.ManifestConfigs[i]
+		if mc.ResourceIdentifier.Group != "argoproj.io" || mc.ResourceIdentifier.Resource != "applications" {
+			continue
+		}
+
+		mc.UpdateStrategy = &workv1.UpdateStrategy{Type: workv1.UpdateStrategyTypeReadOnly}
+	}
 }
 
 // isPullModelManifestWork reports whether mw is one this propagation controller generated,

--- a/propagation-controller/application/pull_model_disable.go
+++ b/propagation-controller/application/pull_model_disable.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+// SweepManifestWorksToReadOnly patches every ManifestWork this propagation controller has
+// ever generated to updateStrategy=ReadOnly, so the spoke's klusterlet work-agent stops
+// re-asserting/enforcing their payload. It is meant to be called once, at startup, only
+// when the basic pull model is disabled (see pkg/pullmodelconfig) -- with Reconcile already
+// a no-op in that state (see application_controller.go and application_status_controller.go),
+// nothing will ever call generateManifestWork again to undo this, so a single pass here is
+// permanently sufficient. Safe to call on every startup regardless: matching ManifestWorks
+// that are already ReadOnly are left untouched, so repeat calls (e.g. across pod restarts)
+// are fast no-ops after the first one actually does the work.
+//
+// Matching is content-based, not name- or position-based, specifically so this cannot ever
+// touch a ManifestWork it doesn't recognize as one of its own:
+//  1. Must carry the hub-application-name annotation -- set only by generateManifestWork,
+//     on nothing else in the system.
+//  2. Must carry one of the two mutually-exclusive ownership labels generateManifestWork
+//     sets depending on whether the source Application came from an ApplicationSet or was
+//     hand-created.
+//  3. Within a matching ManifestWork, only the specific manifestConfigs entry whose
+//     resourceIdentifier is {group: argoproj.io, resource: applications} is touched -- never
+//     by positional index, so any other manifest config entry a ManifestWork might carry is
+//     left completely alone.
+//
+// Deliberately never deletes anything -- see CLAUDE.md for why deleting a pull-model
+// ManifestWork is destructive to the real workload it delivered.
+func SweepManifestWorksToReadOnly(ctx context.Context, c client.Client) error {
+	var mwList workv1.ManifestWorkList
+	if err := c.List(ctx, &mwList); err != nil {
+		return fmt.Errorf("failed to list ManifestWorks for pull-model disable sweep: %w", err)
+	}
+
+	var swept, alreadyDone, skipped int
+
+	for i := range mwList.Items {
+		mw := &mwList.Items[i]
+
+		if !isPullModelManifestWork(mw) {
+			skipped++
+			continue
+		}
+
+		changed := false
+
+		for j := range mw.Spec.ManifestConfigs {
+			mc := &mw.Spec.ManifestConfigs[j]
+			if mc.ResourceIdentifier.Group != "argoproj.io" || mc.ResourceIdentifier.Resource != "applications" {
+				continue
+			}
+
+			if mc.UpdateStrategy != nil && mc.UpdateStrategy.Type == workv1.UpdateStrategyTypeReadOnly {
+				continue
+			}
+
+			mc.UpdateStrategy = &workv1.UpdateStrategy{Type: workv1.UpdateStrategyTypeReadOnly}
+			changed = true
+		}
+
+		if !changed {
+			alreadyDone++
+			continue
+		}
+
+		if err := c.Update(ctx, mw); err != nil {
+			klog.Errorf("pull-model disable sweep: failed to patch ManifestWork %s/%s to ReadOnly: %v", mw.Namespace, mw.Name, err)
+			continue
+		}
+
+		klog.Infof("pull-model disable sweep: patched ManifestWork %s/%s to ReadOnly", mw.Namespace, mw.Name)
+		swept++
+	}
+
+	klog.Infof("pull-model disable sweep complete: %d patched to ReadOnly, %d already ReadOnly, %d not pull-model-owned (skipped)",
+		swept, alreadyDone, skipped)
+
+	return nil
+}
+
+// isPullModelManifestWork reports whether mw is one this propagation controller generated,
+// by content -- never by name or namespace guessing.
+func isPullModelManifestWork(mw *workv1.ManifestWork) bool {
+	if _, ok := mw.Annotations[AnnotationKeyHubApplicationName]; !ok {
+		return false
+	}
+
+	if v, ok := mw.Labels[LabelKeyAppSet]; ok && v == "true" {
+		return true
+	}
+
+	if v, ok := mw.Labels[LabelKeyPull]; ok && v == "true" {
+		return true
+	}
+
+	return false
+}

--- a/propagation-controller/application/pull_model_disable_test.go
+++ b/propagation-controller/application/pull_model_disable_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	workv1 "open-cluster-management.io/api/work/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newSweepTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	s := runtime.NewScheme()
+	if err := workv1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to build test scheme: %v", err)
+	}
+
+	return s
+}
+
+func appSetOwnedManifestWork(name, ns, strategy string) *workv1.ManifestWork {
+	mw := &workv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    map[string]string{LabelKeyAppSet: "true"},
+			Annotations: map[string]string{
+				AnnotationKeyHubApplicationName:      "some-app",
+				AnnotationKeyHubApplicationNamespace: "openshift-gitops",
+			},
+		},
+		Spec: workv1.ManifestWorkSpec{
+			ManifestConfigs: []workv1.ManifestConfigOption{
+				{
+					ResourceIdentifier: workv1.ResourceIdentifier{
+						Group:     "argoproj.io",
+						Resource:  "applications",
+						Namespace: "openshift-gitops",
+						Name:      "some-app",
+					},
+				},
+			},
+		},
+	}
+
+	if strategy != "" {
+		mw.Spec.ManifestConfigs[0].UpdateStrategy = &workv1.UpdateStrategy{Type: workv1.UpdateStrategyType(strategy)}
+	}
+
+	return mw
+}
+
+func TestSweepManifestWorksToReadOnly_PatchesMatchingManifestWork(t *testing.T) {
+	scheme := newSweepTestScheme(t)
+	mw := appSetOwnedManifestWork("app-abcde", "cluster1", "ServerSideApply")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mw).Build()
+
+	if err := SweepManifestWorksToReadOnly(context.Background(), c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &workv1.ManifestWork{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "app-abcde", Namespace: "cluster1"}, got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Spec.ManifestConfigs[0].UpdateStrategy == nil || got.Spec.ManifestConfigs[0].UpdateStrategy.Type != workv1.UpdateStrategyTypeReadOnly {
+		t.Fatalf("expected updateStrategy to be patched to ReadOnly, got %+v", got.Spec.ManifestConfigs[0].UpdateStrategy)
+	}
+}
+
+func TestSweepManifestWorksToReadOnly_StandaloneAppPullLabelAlsoMatches(t *testing.T) {
+	scheme := newSweepTestScheme(t)
+	mw := &workv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-only",
+			Namespace: "cluster1",
+			Labels:    map[string]string{LabelKeyPull: "true"},
+			Annotations: map[string]string{
+				AnnotationKeyHubApplicationName: "some-app",
+			},
+		},
+		Spec: workv1.ManifestWorkSpec{
+			ManifestConfigs: []workv1.ManifestConfigOption{
+				{
+					ResourceIdentifier: workv1.ResourceIdentifier{Group: "argoproj.io", Resource: "applications", Namespace: "argocd", Name: "some-app"},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mw).Build()
+
+	if err := SweepManifestWorksToReadOnly(context.Background(), c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &workv1.ManifestWork{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "app-only", Namespace: "cluster1"}, got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Spec.ManifestConfigs[0].UpdateStrategy == nil || got.Spec.ManifestConfigs[0].UpdateStrategy.Type != workv1.UpdateStrategyTypeReadOnly {
+		t.Fatalf("expected standalone pull-labeled ManifestWork to also be patched to ReadOnly")
+	}
+}
+
+func TestSweepManifestWorksToReadOnly_AlreadyReadOnlyIsNoOp(t *testing.T) {
+	scheme := newSweepTestScheme(t)
+	mw := appSetOwnedManifestWork("already-ro", "cluster1", "ReadOnly")
+	originalGen := mw.Generation
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mw).Build()
+
+	if err := SweepManifestWorksToReadOnly(context.Background(), c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &workv1.ManifestWork{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "already-ro", Namespace: "cluster1"}, got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Generation != originalGen {
+		t.Fatalf("expected no update (generation unchanged) for an already-ReadOnly ManifestWork, got generation %d -> %d", originalGen, got.Generation)
+	}
+}
+
+func TestSweepManifestWorksToReadOnly_UnrelatedManifestWorkUntouched(t *testing.T) {
+	scheme := newSweepTestScheme(t)
+	// No hub-application-name annotation, no pull-model ownership label -- e.g. an
+	// addon-deploy ManifestWork. Must never be touched by the sweep.
+	unrelated := &workv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "addon-gitops-addon-deploy-0",
+			Namespace: "cluster1",
+		},
+		Spec: workv1.ManifestWorkSpec{
+			ManifestConfigs: []workv1.ManifestConfigOption{
+				{
+					ResourceIdentifier: workv1.ResourceIdentifier{Group: "apps", Resource: "deployments", Namespace: "open-cluster-management-agent-addon", Name: "gitops-addon"},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(unrelated).Build()
+
+	if err := SweepManifestWorksToReadOnly(context.Background(), c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &workv1.ManifestWork{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "addon-gitops-addon-deploy-0", Namespace: "cluster1"}, got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Spec.ManifestConfigs[0].UpdateStrategy != nil {
+		t.Fatalf("expected an unrelated ManifestWork to be left completely untouched, got updateStrategy=%+v", got.Spec.ManifestConfigs[0].UpdateStrategy)
+	}
+}
+
+func TestSweepManifestWorksToReadOnly_OnlyTouchesApplicationsManifestConfig(t *testing.T) {
+	scheme := newSweepTestScheme(t)
+	mw := &workv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multi-config",
+			Namespace: "cluster1",
+			Labels:    map[string]string{LabelKeyAppSet: "true"},
+			Annotations: map[string]string{
+				AnnotationKeyHubApplicationName: "some-app",
+			},
+		},
+		Spec: workv1.ManifestWorkSpec{
+			ManifestConfigs: []workv1.ManifestConfigOption{
+				{
+					// A hypothetical second entry for a different resource -- must be
+					// left alone even though this ManifestWork matches overall.
+					ResourceIdentifier: workv1.ResourceIdentifier{Group: "", Resource: "namespaces", Name: "guestbook"},
+				},
+				{
+					ResourceIdentifier: workv1.ResourceIdentifier{Group: "argoproj.io", Resource: "applications", Namespace: "openshift-gitops", Name: "some-app"},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mw).Build()
+
+	if err := SweepManifestWorksToReadOnly(context.Background(), c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &workv1.ManifestWork{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "multi-config", Namespace: "cluster1"}, got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Spec.ManifestConfigs[0].UpdateStrategy != nil {
+		t.Fatalf("expected the namespaces manifestConfig entry to be untouched, got %+v", got.Spec.ManifestConfigs[0].UpdateStrategy)
+	}
+
+	if got.Spec.ManifestConfigs[1].UpdateStrategy == nil || got.Spec.ManifestConfigs[1].UpdateStrategy.Type != workv1.UpdateStrategyTypeReadOnly {
+		t.Fatalf("expected the applications manifestConfig entry to be patched to ReadOnly, got %+v", got.Spec.ManifestConfigs[1].UpdateStrategy)
+	}
+}


### PR DESCRIPTION
Lets operators disable the classic ManifestWork-based pull model hub-wide via a multicluster-integrations-config ConfigMap, so apps can be migrated to argocd-agent without deleting or recreating them.

- pkg/pullmodelconfig: self-provisioning ConfigMap (pullModel.basic.disabled), namespace resolved dynamically, never hardcoded
- propagation, gitopssyncresc, multiclusterstatusaggregation controllers check the flag live on every reconcile/tick (not cached at startup) so a rolling restart can't race a stale in-flight event past the disable
- one-time startup sweep freezes existing pull-model ManifestWorks to ReadOnly, content-matched, without deleting anything
- rewrite the basic-pull-to-argocd-agent migration runbook to cover both ApplicationSet-owned and standalone apps, and document the required step to replace an app's stale pre-agent spoke-side copy

No behavior change when pullModel.basic.disabled is false (default).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cluster-based configuration to enable or disable the basic pull model.
  * When disabled, affected delivery resources are set to ReadOnly, while syncing and status processing are skipped.
* **Bug Fixes**
  * Improved targeted updates and conflict handling during ReadOnly transitions.
* **Documentation**
  * Expanded the migration runbook to `argocd-agent` with safer configuration, verification, and cleanup guidance.
* **Tests**
  * Added coverage for configuration loading, creation races, and precise ReadOnly targeting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->