### PR TITLE
ACM-39032: Bump Go to 1.26 to address CVE-2026-27145

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/multicloud-integrations/multicloud-integrations/go'
 defaults:

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/multicloud-integrations/multicloud-integrations/go'
 defaults:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*.*.*'
 env:
   # Common versions
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/multicloud-integrations/multicloud-integrations/go'
   GITHUB_REF: ${{ github.ref }}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.23-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /go/src/github.com/open-cluster-management-io/multicloud-integrations
 COPY . .

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.23-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /go/src/github.com/stolostron/multicloud-integrations
 COPY . .

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS plugin-builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS plugin-builder
 
 WORKDIR /go/src/github.com/stolostron/multicloud-integrations
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module open-cluster-management.io/multicloud-integrations
 
-go 1.23.0
-
-toolchain go1.23.7
+go 1.26
 
 require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32

--- a/pkg/controller/gitopssyncresc/gitopssyncresc_controller.go
+++ b/pkg/controller/gitopssyncresc/gitopssyncresc_controller.go
@@ -196,7 +196,7 @@ func (r *GitOpsSyncResource) syncResources() error {
 				appsetNsn := strings.Split(hostingAppsetName.(string), "/")
 				if len(appsetNsn) != 3 {
 					err := fmt.Errorf("_hostingResource is not in the correct format: %v", hostingAppsetName)
-					klog.Infof(err.Error())
+					klog.Info(err.Error())
 
 					return err
 				}


### PR DESCRIPTION
## Summary

Bump Go builder images from 1.23 to 1.26 to address CVE-2026-27145 (crypto/x509 DoS).

## Changes

- `go.mod`: `go 1.23.0` → `go 1.26` (removed `toolchain go1.23.7`)
- `build/Dockerfile`: stolostron builder `go1.23-linux` → `go1.26-linux`
- `build/Dockerfile.prow`: stolostron builder `go1.23-linux` → `go1.26-linux`
- `build/Dockerfile.rhtap`: brew builder `rhel_9_1.23` → `rhel_9_1.26`
- `.github/workflows/go-release.yml`: Go version `1.23` → `1.26`
- `.github/workflows/go-presubmit.yml`: Go version `1.23` → `1.26`
- `.github/workflows/go-postsubmit.yml`: Go version `1.23` → `1.26`

Made with [Cursor](https://cursor.com)