### PR TITLE
[release-2.15] Bump Go to 1.26 to address CVE-2026-27145

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
       - release-*
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/multicloud-integrations/multicloud-integrations/go'
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /go/src/github.com/open-cluster-management-io/multicloud-integrations
 COPY . .

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /go/src/github.com/stolostron/multicloud-integrations
 COPY . .

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS plugin-builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS plugin-builder
 
 WORKDIR /go/src/github.com/stolostron/multicloud-integrations
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/multicloud-integrations
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/ghodss/yaml v1.0.1-0.20220118164431-d8423dcdf344


### PR DESCRIPTION
## Summary
- Bump Go from 1.25 to **1.26** to remediate **CVE-2026-27145** (GO-2026-5037: inefficient `crypto/x509` hostname verification / DoS).
- Update CI (`kind.yml`) and builder images (`Dockerfile`, `Dockerfile.prow`, `Dockerfile.rhtap`) to the Go 1.26 builders.
- Backport of the approach in https://github.com/stolostron/multicloud-operators-channel/pull/513 for `release-2.14`.

## Why this remediates the CVE
CVE-2026-27145 is fixed in Go **≥ 1.25.11** or **≥ 1.26.4**. The floating builders used after this change currently provide **Go 1.26.5**:
- `registry.ci.openshift.org/stolostron/builder:go1.26-linux` → `GOVERSION=1.26.5`
- `brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26` → `v1.26.5`
